### PR TITLE
[IDP-433] port abstractions project

### DIFF
--- a/src/Workleap.DomainEventPropagation.Abstractions/IDomainEvent.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/IDomainEvent.cs
@@ -1,0 +1,7 @@
+namespace Workleap.DomainEventPropagation
+{
+    public interface IDomainEvent
+    {
+        string DataVersion { get; }
+    }
+}

--- a/src/Workleap.DomainEventPropagation.Abstractions/ITopicProvider.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/ITopicProvider.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Workleap.DomainEventPropagation
 {
     public interface ITopicProvider

--- a/src/Workleap.DomainEventPropagation.Abstractions/ITopicProvider.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/ITopicProvider.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Workleap.DomainEventPropagation
+{
+    public interface ITopicProvider
+    {
+        IEnumerable<string> GetAllTopicsNames();
+
+        IEnumerable<string> GetAllTopicValidationPatterns();
+
+        string GetTopicValidationPattern(string topicName);
+    }
+}

--- a/src/Workleap.DomainEventPropagation.Abstractions/PublicApi.Shipped.txt
+++ b/src/Workleap.DomainEventPropagation.Abstractions/PublicApi.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Workleap.DomainEventPropagation.Abstractions/PublicApi.Unshipped.txt
+++ b/src/Workleap.DomainEventPropagation.Abstractions/PublicApi.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Workleap.DomainEventPropagation.Abstractions/Workleap.DomainEventPropagation.Abstractions.csproj
+++ b/src/Workleap.DomainEventPropagation.Abstractions/Workleap.DomainEventPropagation.Abstractions.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+   <PropertyGroup>
+    <!-- Temporarily disable public API analyzers until API has been stabilized -->
+    <NoWarn>RS0016,RS0037,$(NoWarn)</NoWarn>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../Workleap.DomainEventPropagation.snk</AssemblyOriginatorKeyFile>
+    <RootNamespace>Workleap.DomainEventPropagation</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Link="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Exposes internal symbols to test projects and mocking libraries -->
+    <InternalsVisibleTo Include="Workleap.DomainEventPropagation.Tests,PublicKey=002400000480000094000000060200000024000052534131000400000100010025301ce547647ab5ac9264ade0f9cdc0252796a257095add4791b0232c1def21bb9e0c87d218713f918565b23394362dbcb058e210c853a24ec33e6925ebedf654a0d65efb3828c855ff21eaaa67aeb9b24b81b8baff582a03df6ab04424c7e53cacbfe84d2765ce840389f900c55824d037d2c5b6b330ac0188a06ef6869dba" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
+  </ItemGroup>
+
+</Project>

--- a/src/Workleap.DomainEventPropagation.sln
+++ b/src/Workleap.DomainEventPropagation.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{3B3625CC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Workleap.DomainEventPropagation.Tests", "Workleap.DomainEventPropagation.Tests\Workleap.DomainEventPropagation.Tests.csproj", "{2A5429CC-E179-47E7-85BB-C1E33E2AFD8A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Workleap.DomainEventPropagation.Abstractions", "Workleap.DomainEventPropagation.Abstractions\Workleap.DomainEventPropagation.Abstractions.csproj", "{0E6521C9-28A3-40BC-B960-F558322E58E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{2A5429CC-E179-47E7-85BB-C1E33E2AFD8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A5429CC-E179-47E7-85BB-C1E33E2AFD8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A5429CC-E179-47E7-85BB-C1E33E2AFD8A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E6521C9-28A3-40BC-B960-F558322E58E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E6521C9-28A3-40BC-B960-F558322E58E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E6521C9-28A3-40BC-B960-F558322E58E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E6521C9-28A3-40BC-B960-F558322E58E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Port over the original abstractions project, but with minor tweaks to retrofit with our current solution:
- Use the same namespace as the main package
- Added support for assembly signage with the same `.snk` key as the main package
- Include symbols as `snupkg`
- Link to the main package's `README`
- Use public API analyzers:
   -  Disable the current warnings for the time being, until the code has been stabilized across the board
- Make internal types visible to the tests project and `DynamicProxyGenAssembly2` (e.g. for Moq)