### PR TITLE
[IDP-453] feat(refactor): Event Grid publisher client setup

### DIFF
--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
-using Azure;
-using Azure.Core;
 using Azure.Messaging.EventGrid;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Options;
 using Workleap.DomainEventPropagation.Exceptions;
 
@@ -10,25 +9,28 @@ namespace Workleap.DomainEventPropagation;
 /// <summary>
 /// https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventgrid/Azure.Messaging.EventGrid/README.md
 /// </summary>
-internal class EventPropagationClient : IEventPropagationClient
+internal sealed class EventPropagationClient : IEventPropagationClient
 {
     private static readonly JsonSerializerOptions SerializerOptions = new();
-
+    
     private readonly EventPropagationPublisherOptions _eventPropagationPublisherOptions;
+    private readonly IAzureClientFactory<EventGridPublisherClient> _eventGridPublisherClientFactory;
     private readonly ITelemetryClientProvider _telemetryClientProvider;
 
     public EventPropagationClient(
+        IAzureClientFactory<EventGridPublisherClient> eventGridPublisherClientFactory,
         IOptions<EventPropagationPublisherOptions> eventPropagationPublisherOptions,
         ITelemetryClientProvider telemetryClientProvider)
     {
         this._eventPropagationPublisherOptions = eventPropagationPublisherOptions.Value;
+        this._eventGridPublisherClientFactory = eventGridPublisherClientFactory;
         this._telemetryClientProvider = telemetryClientProvider;
     }
 
-    public async Task PublishDomainEventAsync(string subject, IDomainEvent domainEvent, CancellationToken cancellationToken)
-    {
-        await this.PublishDomainEventsAsync(subject, new[] { domainEvent }, cancellationToken);
-    }
+    private string TopicName => this._eventPropagationPublisherOptions.TopicName;
+
+    public Task PublishDomainEventAsync(string subject, IDomainEvent domainEvent, CancellationToken cancellationToken)
+        => this.PublishDomainEventsAsync(subject, new[] { domainEvent }, cancellationToken);
 
     public Task PublishDomainEventAsync<T>(T domainEvent, CancellationToken cancellationToken) where T : IDomainEvent
         => this.PublishDomainEventAsync(typeof(T).FullName, domainEvent, cancellationToken);
@@ -38,49 +40,37 @@ internal class EventPropagationClient : IEventPropagationClient
 
     public async Task PublishDomainEventsAsync(string subject, IEnumerable<IDomainEvent> domainEvents, CancellationToken cancellationToken)
     {
-        var topicName = this._eventPropagationPublisherOptions.TopicName;
-        var topicEndpoint = this._eventPropagationPublisherOptions.TopicEndpoint;
-        var topicAccessKey = this._eventPropagationPublisherOptions.TopicAccessKey;
-
-        var topicEndpointUri = new Uri(topicEndpoint);
-        var topicCredentials = new AzureKeyCredential(topicAccessKey);
-        var client = new EventGridPublisherClient(
-            topicEndpointUri,
-            topicCredentials,
-            new EventGridPublisherClientOptions
-            {
-                Retry = { Mode = RetryMode.Fixed, MaxRetries = 1, NetworkTimeout = TimeSpan.FromSeconds(4) }
-            });
+        var domainEventTypes = TelemetryHelper.GetDomainEventTypes(domainEvents);
 
         try
         {
-            var eventGridEvents = GetEventsList(topicName, subject, domainEvents);
+            var eventGridEvents = this.GetEventsList(subject, domainEvents);
 
-            await client.SendEventsAsync(eventGridEvents, cancellationToken);
+            await this._eventGridPublisherClientFactory.CreateClient(EventPropagationPublisherOptions.ClientName).SendEventsAsync(eventGridEvents, cancellationToken);
 
-            this._telemetryClientProvider.TrackEvent(TelemetryConstants.DomainEventsPropagated, $"Propagated domain event with subject '{subject}' on topic '{topicName}'", TelemetryHelper.GetDomainEventTypes(domainEvents));
+            this._telemetryClientProvider.TrackEvent(TelemetryConstants.DomainEventsPropagated, $"Propagated domain event with subject '{subject}' on topic '{this.TopicName}'", domainEventTypes);
         }
         catch (Exception ex)
         {
             var exception = new EventPropagationPublishingException("An error occured while publishing events to EventGrid", ex)
             {
-                TopicName = topicName,
+                TopicName = this.TopicName,
                 Subject = subject,
-                TopicEndpoint = topicEndpoint
+                TopicEndpoint = this._eventPropagationPublisherOptions.TopicEndpoint
             };
 
-            this._telemetryClientProvider.TrackEvent(TelemetryConstants.DomainEventsPropagationFailed, $"Domain event propagation failed with subject '{subject}' on topic '{topicName}'", TelemetryHelper.GetDomainEventTypes(domainEvents));
+            this._telemetryClientProvider.TrackEvent(TelemetryConstants.DomainEventsPropagationFailed, $"Domain event propagation failed with subject '{subject}' on topic '{this.TopicName}'", domainEventTypes);
             this._telemetryClientProvider.TrackException(exception);
 
             throw exception;
         }
     }
 
-    private static IEnumerable<EventGridEvent> GetEventsList(string topic, string subject, IEnumerable<IDomainEvent> domainEvents)
+    private IEnumerable<EventGridEvent> GetEventsList(string subject, IEnumerable<IDomainEvent> domainEvents)
     {
         // TODO: Propagate correlation ID by setting data with "telemetryCorrelationId" property when OpenTelemetry is fully supported
         return domainEvents.Select(domainEvent => new EventGridEvent(
-            subject: $"{topic}-{subject}",
+            subject: $"{this.TopicName}-{subject}",
             eventType: domainEvent.GetType().FullName,
             dataVersion: domainEvent.DataVersion,
             data: new BinaryData(domainEvent, SerializerOptions)));

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
@@ -48,7 +48,7 @@ internal sealed class EventPropagationClient : IEventPropagationClient
 
             await this._eventGridPublisherClientFactory.CreateClient(EventPropagationPublisherOptions.ClientName).SendEventsAsync(eventGridEvents, cancellationToken);
 
-            this._telemetryClientProvider.TrackEvent(TelemetryConstants.DomainEventsPropagated, $"Propagated domain event with subject '{subject}' on topic '{this.TopicName}'", domainEventTypes);
+            this._telemetryClientProvider.TrackEvent(TelemetryConstants.DomainEventsPropagated, $"Published domain event with subject '{subject}' on topic '{this.TopicName}'", domainEventTypes);
         }
         catch (Exception ex)
         {
@@ -59,7 +59,7 @@ internal sealed class EventPropagationClient : IEventPropagationClient
                 TopicEndpoint = this._eventPropagationPublisherOptions.TopicEndpoint
             };
 
-            this._telemetryClientProvider.TrackEvent(TelemetryConstants.DomainEventsPropagationFailed, $"Domain event propagation failed with subject '{subject}' on topic '{this.TopicName}'", domainEventTypes);
+            this._telemetryClientProvider.TrackEvent(TelemetryConstants.DomainEventsPropagationFailed, $"Failed to publish domain event with subject '{subject}' on topic '{this.TopicName}'", domainEventTypes);
             this._telemetryClientProvider.TrackException(exception);
 
             throw exception;

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptions.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptions.cs
@@ -5,7 +5,9 @@ namespace Workleap.DomainEventPropagation;
 
 public sealed class EventPropagationPublisherOptions
 {
-    internal const string SectionName = "EventPropagation";
+    internal const string SectionName = "EventPropagation:Publisher";
+
+    internal const string ClientName = "EventPropagationClient";
 
     [Required]
     public string TopicName { get; set; }

--- a/src/Workleap.DomainEventPropagation.Publishing/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
+using Azure;
+using Azure.Core;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace Workleap.DomainEventPropagation.Extensions;
@@ -7,21 +11,55 @@ namespace Workleap.DomainEventPropagation.Extensions;
 [ExcludeFromCodeCoverage]
 public static class ServiceCollectionEventPropagationExtensions
 {
-    public static IEventPropagationPublisherBuilder AddEventPropagation(this IServiceCollection services)
-    {
-        services.AddSingleton<IEventPropagationClient, EventPropagationClient>();
-        services.AddSingleton<ITelemetryClientProvider, TelemetryClientProvider>();
+    public static IEventPropagationPublisherBuilder AddEventPropagationPublisher(this IServiceCollection services)
+        => services.AddEventPropagationPublisher(_ => { });
 
-        services.AddEventPropagationPublisherOptions();
+    public static IEventPropagationPublisherBuilder AddEventPropagationPublisher(this IServiceCollection services, Action<EventPropagationPublisherOptions> configure)
+    {
+        if (services == null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
+        if (configure == null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+
+        services.TryAddSingleton<IEventPropagationClient, EventPropagationClient>();
+        services.TryAddSingleton<ITelemetryClientProvider, TelemetryClientProvider>();
+
+        services.AddEventPropagationPublisherOptions(configure);
+
+        services.AddAzureClients(builder =>
+        {
+            using var sp = services.BuildServiceProvider();
+
+            var options = sp.GetRequiredService<IOptions<EventPropagationPublisherOptions>>().Value;
+
+            var topicEndpointUri = new Uri(options.TopicEndpoint);
+            var topicCredentials = new AzureKeyCredential(options.TopicAccessKey);
+
+            builder
+                .AddEventGridPublisherClient(topicEndpointUri, topicCredentials)
+                .WithName(EventPropagationPublisherOptions.ClientName)
+                .ConfigureOptions(clientOptions =>
+                {
+                    clientOptions.Retry.Mode = RetryMode.Fixed;
+                    clientOptions.Retry.MaxRetries = 1;
+                    clientOptions.Retry.NetworkTimeout = TimeSpan.FromSeconds(4);
+                });
+        });
 
         return new EventPropagationPublisherBuilder(services);
     }
 
-    internal static IServiceCollection AddEventPropagationPublisherOptions(this IServiceCollection services)
+    internal static IServiceCollection AddEventPropagationPublisherOptions(this IServiceCollection services, Action<EventPropagationPublisherOptions> configure)
     {
         services
             .AddOptions<EventPropagationPublisherOptions>()
             .BindConfiguration(EventPropagationPublisherOptions.SectionName)
+            .PostConfigure(configure)
             .ValidateDataAnnotations()
             .ValidateOnStart();
 

--- a/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
@@ -26,6 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />

--- a/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsTests.cs
+++ b/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsTests.cs
@@ -42,9 +42,9 @@ public class EventPropagationPublisherOptionsTests
         TopicProviderMock.Setup(x => x.GetAllTopicsNames()).Returns(new[] { "Organization", "Signup" });
         services.AddSingleton(TopicProviderMock.Object);
         services.AddSingleton<IConfiguration>(configuration);
-        services.AddEventPropagationPublisherOptions();
+        services.AddEventPropagationPublisherOptions(_ => { });
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
 
         Assert.Throws<OptionsValidationException>(() => serviceProvider.GetService<IOptions<EventPropagationPublisherOptions>>().Value);
     }
@@ -68,9 +68,9 @@ public class EventPropagationPublisherOptionsTests
         TopicProviderMock.Setup(x => x.GetAllTopicsNames()).Returns(new[] { "Organization", "Signup" });
         services.AddSingleton(TopicProviderMock.Object);
         services.AddSingleton<IConfiguration>(configuration);
-        services.AddEventPropagationPublisherOptions();
+        services.AddEventPropagationPublisherOptions(_ => { });
 
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
 
         var options = serviceProvider.GetService<IOptions<EventPropagationPublisherOptions>>().Value;
 

--- a/src/Workleap.DomainEventPropagation.Tests/Workleap.DomainEventPropagation.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Tests/Workleap.DomainEventPropagation.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
## Core changes
Refactor out the `EventGridPublisherClient` configuration from the event propagation client into the dependency injection registration by leveraging `Microsoft.Azure.Extensions`' extension methods

## Miscellaneous changes
Install and use `FakeItEasy` for related unit tests