### PR TITLE
IDP-513 Improve assembly scanning by filtering

### DIFF
--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
@@ -58,7 +58,7 @@ internal sealed class EventPropagationClient : IEventPropagationClient
         // TODO: Propagate correlation ID by setting data with "telemetryCorrelationId" property when OpenTelemetry is fully supported
         return domainEvents.Select(domainEvent => new EventGridEvent(
             subject: $"{this.TopicName}-{typeof(T).FullName!}",
-            eventType: domainEvent.GetType().FullName,
+            eventType: domainEvent.GetType().AssemblyQualifiedName,
             dataVersion: domainEvent.DataVersion,
             data: new BinaryData(domainEvent, SerializerOptions)));
     }

--- a/src/Workleap.DomainEventPropagation.Tests/Subscription/Events/EventsApiIntegrationTests.cs
+++ b/src/Workleap.DomainEventPropagation.Tests/Subscription/Events/EventsApiIntegrationTests.cs
@@ -76,7 +76,7 @@ public class EventsApiIntegrationTests : IClassFixture<EventsApiIntegrationTests
 
         var eventGridEvent = new EventGridEvent(
             subject: typeof(DummyDomainEvent).FullName,
-            eventType: typeof(DummyDomainEvent).FullName,
+            eventType: typeof(DummyDomainEvent).AssemblyQualifiedName,
             dataVersion: "1.0",
             data: new BinaryData(dummyDomainEvent, SerializerOptions))
         {

--- a/src/Workleap.DomainEventPropagation.sln
+++ b/src/Workleap.DomainEventPropagation.sln
@@ -17,14 +17,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Workleap.DomainEventPropaga
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Workleap.DomainEventPropagation.Subscription", "Workleap.DomainEventPropagation.Subscription\Workleap.DomainEventPropagation.Subscription.csproj", "{1109EBB3-EF74-4C84-85B5-FDE7975FC705}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceA", "ServiceA\ServiceA.csproj", "{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceB", "ServiceB\ServiceB.csproj", "{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceA.Contracts", "ServiceA.Contracts\ServiceA.Contracts.csproj", "{B57B9688-22B1-46D6-9C52-BC4C6F585036}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceB.Contracts", "ServiceB.Contracts\ServiceB.Contracts.csproj", "{CB93B77C-0903-4C27-8B26-28C72031B3F5}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,22 +39,6 @@ Global
 		{1109EBB3-EF74-4C84-85B5-FDE7975FC705}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1109EBB3-EF74-4C84-85B5-FDE7975FC705}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1109EBB3-EF74-4C84-85B5-FDE7975FC705}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B57B9688-22B1-46D6-9C52-BC4C6F585036}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B57B9688-22B1-46D6-9C52-BC4C6F585036}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B57B9688-22B1-46D6-9C52-BC4C6F585036}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B57B9688-22B1-46D6-9C52-BC4C6F585036}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CB93B77C-0903-4C27-8B26-28C72031B3F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CB93B77C-0903-4C27-8B26-28C72031B3F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CB93B77C-0903-4C27-8B26-28C72031B3F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CB93B77C-0903-4C27-8B26-28C72031B3F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Workleap.DomainEventPropagation.sln
+++ b/src/Workleap.DomainEventPropagation.sln
@@ -17,6 +17,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Workleap.DomainEventPropaga
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Workleap.DomainEventPropagation.Subscription", "Workleap.DomainEventPropagation.Subscription\Workleap.DomainEventPropagation.Subscription.csproj", "{1109EBB3-EF74-4C84-85B5-FDE7975FC705}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceA", "ServiceA\ServiceA.csproj", "{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceB", "ServiceB\ServiceB.csproj", "{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceA.Contracts", "ServiceA.Contracts\ServiceA.Contracts.csproj", "{B57B9688-22B1-46D6-9C52-BC4C6F585036}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceB.Contracts", "ServiceB.Contracts\ServiceB.Contracts.csproj", "{CB93B77C-0903-4C27-8B26-28C72031B3F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +47,22 @@ Global
 		{1109EBB3-EF74-4C84-85B5-FDE7975FC705}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1109EBB3-EF74-4C84-85B5-FDE7975FC705}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1109EBB3-EF74-4C84-85B5-FDE7975FC705}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EA4720D-B1DE-4997-ADDA-427A7AD72F3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{485A6CBA-65F3-4E1B-8B8F-2582FC2A6666}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B57B9688-22B1-46D6-9C52-BC4C6F585036}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B57B9688-22B1-46D6-9C52-BC4C6F585036}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B57B9688-22B1-46D6-9C52-BC4C6F585036}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B57B9688-22B1-46D6-9C52-BC4C6F585036}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB93B77C-0903-4C27-8B26-28C72031B3F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB93B77C-0903-4C27-8B26-28C72031B3F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB93B77C-0903-4C27-8B26-28C72031B3F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB93B77C-0903-4C27-8B26-28C72031B3F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Context
The current library we started off would scan assemblies with a hardoded name filter in order to retrieve the domain event type. It works in that team's usecase but not when applied to any team. So we needed to change that to be more flexible while also not scanning all the Microsoft assemblies.

## What's changed
Turns out we control the info sent with the event and when we get the Type of event in the publisher package we can use AssemblyQualifiedName instead of FullName currently. AssemblyQualifiedName contains the full namespace but also which assembly it comes from. Using this makes it simpler afterwards to retrieve the Type in the subscriber package.

- Use AssemblyQualifiedName instead of FullName in the subscriber library when creating the EventGridEvent in EventPropagationClient
- Use Type.GetType instead of iterating over assemblies in the DomainEventGridWebhookHandler