### PR TITLE
IDP-527 - Remove moq

### DIFF
--- a/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsValidatorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsValidatorTests.cs
@@ -3,7 +3,6 @@ using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Moq;
 using Workleap.DomainEventPropagation.Extensions;
 
 namespace Workleap.DomainEventPropagation.Tests.Publishing;

--- a/src/Workleap.DomainEventPropagation.Tests/Subscription/EventGridRequestHandlerTests.cs
+++ b/src/Workleap.DomainEventPropagation.Tests/Subscription/EventGridRequestHandlerTests.cs
@@ -160,7 +160,7 @@ public class EventGridRequestHandlerTests
     private static string GetEventGridSubscriptionRequest(string validationCode)
     {
         var subscriptionRequest = @"[{
-                'topic': '/subscriptions/Organization-egt-',
+                'topic': '/subscriptions/topic-egt-',
                 'subject': '',
                 'eventType': 'Microsoft.EventGrid.SubscriptionValidationEvent',
                 'eventTime': '2017-08-16T01:57:26.005121Z',
@@ -172,7 +172,7 @@ public class EventGridRequestHandlerTests
 
         var eventData = @"{
                   'validationCode': '{validationCode}',
-                  'validationUrl': 'https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=512d38b6-c7b8-40c8-89fe-f46f9e9622b6&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1A1A1A1A'
+                  'validationUrl': 'https://validationurl.io'
             }";
 
         eventData = eventData.Replace("'", "\"");
@@ -183,7 +183,7 @@ public class EventGridRequestHandlerTests
     private static string GetEventGridDomainEventRequest()
     {
         var domainEventRequest = @"[{
-                'topic': '/subscriptions/Organization-egt-',
+                'topic': '/subscriptions/topic-egt-',
                 'subject': 'Test',
                 'eventType': 'Workleap.Organization.DomainEvents.ExampleDomainEvent',
                 'eventTime': '2017-08-16T01:57:26.005121Z',
@@ -194,8 +194,8 @@ public class EventGridRequestHandlerTests
              }]";
 
         var eventData = @"{
-                  'coolDate': '2017-08-16T01:57:26.005121Z',
-                  'coolId': 'b59ff87c-9bfb-46b7-9092-04735202d2f6'
+                  'eventDate': '2017-08-16T01:57:26.005121Z',
+                  'eventId': 'b59ff87c-9bfb-46b7-9092-04735202d2f6'
                 }";
 
         eventData = eventData.Replace("'", "\"");

--- a/src/Workleap.DomainEventPropagation.Tests/Subscription/SubscriptionEventWebhookHandlerTests.cs
+++ b/src/Workleap.DomainEventPropagation.Tests/Subscription/SubscriptionEventWebhookHandlerTests.cs
@@ -1,5 +1,4 @@
 using Azure.Messaging.EventGrid.SystemEvents;
-using Moq;
 using BindingFlags = System.Reflection.BindingFlags;
 
 namespace Workleap.DomainEventPropagation.Tests.Subscription;

--- a/src/Workleap.DomainEventPropagation.Tests/Workleap.DomainEventPropagation.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Tests/Workleap.DomainEventPropagation.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.20" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Context
In order to keep our libs unified, we want all of them to use FakeItEasy. So we need to change the remaining tests that use moq.

## What was done
- Removed moq package from our test project
- Adjusted EventGridRequestHandlerTests to use FakeItEasy instead of moq