### PR TITLE
IDP-528 - Remove options validation attributes

### DIFF
--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptions.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptions.cs
@@ -1,6 +1,4 @@
-using System.ComponentModel.DataAnnotations;
 using Azure.Core;
-using GSoft.ComponentModel.DataAnnotations;
 
 namespace Workleap.DomainEventPropagation;
 
@@ -10,14 +8,11 @@ public sealed class EventPropagationPublisherOptions
 
     internal const string ClientName = "EventPropagationClient";
 
-    [Required]
     public string TopicName { get; set; } = string.Empty;
 
     public string TopicAccessKey { get; set; } = string.Empty;
 
     public TokenCredential? TokenCredential { get; set; }
 
-    [Required]
-    [UrlOfKind(UriKind.Absolute)]
     public string TopicEndpoint { get; set; } = string.Empty;
 }

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptionsValidator.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptionsValidator.cs
@@ -16,19 +16,12 @@ public sealed class EventPropagationPublisherOptionsValidator : IValidateOptions
             return ValidateOptionsResult.Fail("A topic name is required");
         }
 
-        if (options.TopicEndpoint is null or { Length: 0 })
+        if (string.IsNullOrWhiteSpace(options.TopicEndpoint))
         {
             return ValidateOptionsResult.Fail("A topic endpoint is required");
         }
 
-        try
-        {
-            if (new Uri(options.TopicEndpoint).IsAbsoluteUri == false)
-            {  
-                return ValidateOptionsResult.Fail("The topic endpoint must be an absolute URI");
-            }
-        }
-        catch (UriFormatException)
+        if (!Uri.TryCreate(options.TopicEndpoint, UriKind.Absolute, out var uri))
         {
             return ValidateOptionsResult.Fail("The topic endpoint must be an absolute URI");
         }

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptionsValidator.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptionsValidator.cs
@@ -11,6 +11,28 @@ public sealed class EventPropagationPublisherOptionsValidator : IValidateOptions
             return ValidateOptionsResult.Fail("A token credential or an access key is required");
         }
 
+        if (string.IsNullOrWhiteSpace(options.TopicName))
+        {
+            return ValidateOptionsResult.Fail("A topic name is required");
+        }
+
+        if (options.TopicEndpoint is null or { Length: 0 })
+        {
+            return ValidateOptionsResult.Fail("A topic endpoint is required");
+        }
+
+        try
+        {
+            if (new Uri(options.TopicEndpoint).IsAbsoluteUri == false)
+            {  
+                return ValidateOptionsResult.Fail("The topic endpoint must be an absolute URI");
+            }
+        }
+        catch (UriFormatException)
+        {
+            return ValidateOptionsResult.Fail("The topic endpoint must be an absolute URI");
+        }
+
         return ValidateOptionsResult.Success;
     }
 }

--- a/src/Workleap.DomainEventPropagation.Publishing/Extensions/ServiceCollectionEventPropagationExtensions.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/Extensions/ServiceCollectionEventPropagationExtensions.cs
@@ -58,7 +58,6 @@ public static class ServiceCollectionEventPropagationExtensions
             .AddOptions<EventPropagationPublisherOptions>()
             .BindConfiguration(EventPropagationPublisherOptions.SectionName)
             .Configure(configure)
-            .ValidateDataAnnotations()
             .ValidateOnStart();
 
         services.AddSingleton<IValidateOptions<EventPropagationPublisherOptions>, EventPropagationPublisherOptionsValidator>();

--- a/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.17.0" />
-    <PackageReference Include="GSoft.ComponentModel.DataAnnotations" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Workleap.DomainEventPropagation.Subscription/Workleap.DomainEventPropagation.Subscription.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription/Workleap.DomainEventPropagation.Subscription.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsTests.cs
+++ b/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsTests.cs
@@ -7,38 +7,6 @@ namespace Workleap.DomainEventPropagation.Tests.Publishing;
 
 public class EventPropagationPublisherOptionsTests
 {
-    [Theory]
-    [InlineData(null, null, null)]
-    [InlineData(" ", "accessKey", "http://topicurl.com")]
-    [InlineData(null, "accessKey", "http://topicurl.com")]
-    [InlineData("topicName", " ", "http://topicurl.com")]
-    [InlineData("topicName", null, "http://topicurl.com")]
-    [InlineData("topicName", "accessKey", " ")]
-    [InlineData("topicName", "accessKey", null)]
-    [InlineData("topicName", "accessKey", "topicEndpoint")]
-    public void GivenEventPropagationConfiguration_WhenOptionsAreInvalid_ThrowsException(string topicName, string topicAccessKey, string topicEndpoint)
-    {
-        var myConfiguration = new Dictionary<string, string>
-        {
-            { $"{EventPropagationPublisherOptions.SectionName}:{nameof(EventPropagationPublisherOptions.TopicName)}", topicName },
-            { $"{EventPropagationPublisherOptions.SectionName}:{nameof(EventPropagationPublisherOptions.TopicEndpoint)}", topicEndpoint },
-            { $"{EventPropagationPublisherOptions.SectionName}:{nameof(EventPropagationPublisherOptions.TopicAccessKey)}", topicAccessKey },
-        };
-
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(myConfiguration)
-            .Build();
-
-        var services = new ServiceCollection();
-
-        services.AddSingleton<IConfiguration>(configuration);
-        services.AddEventPropagationPublisherOptions(_ => { });
-
-        using var serviceProvider = services.BuildServiceProvider();
-
-        Assert.Throws<OptionsValidationException>(() => serviceProvider.GetRequiredService<IOptions<EventPropagationPublisherOptions>>().Value);
-    }
-
     [Fact]
     public void GivenEventPropagationConfigurationAsIConfiguration_WhenLoadedProperly_ThenPropertiesMatch()
     {

--- a/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsValidatorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsValidatorTests.cs
@@ -14,6 +14,14 @@ public class EventPropagationPublisherOptionsValidatorTests
     [InlineData("topicName", " ", "http://topicurl.com", false, false)]
     [InlineData("topicName", "accessKey", "http://topicurl.com", true, true)]
     [InlineData("topicName", "accessKey", "http://topicurl.com", false, true)]
+    [InlineData(null, null, null, false, false)]
+    [InlineData(" ", "accessKey", "http://topicurl.com", false, false)]
+    [InlineData(null, "accessKey", "http://topicurl.com", false, false)]
+    [InlineData("topicName", " ", "http://topicurl.com", false, false)]
+    [InlineData("topicName", null, "http://topicurl.com", false, false)]
+    [InlineData("topicName", "accessKey", " ", false, false)]
+    [InlineData("topicName", "accessKey", null, false, false)]
+    [InlineData("topicName", "accessKey", "topicEndpoint", false, false)]
     public void GivenEventPropagationConfigurations_WhenValidateOptions_ThenAccessCredentialsValidated(string topicName, string topicAccessKey, string topicEndpoint, bool useTokenCredential, bool optionsValid)
     {
         var validator = new EventPropagationPublisherOptionsValidator();

--- a/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsValidatorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Tests/Publishing/EventPropagationPublisherOptionsValidatorTests.cs
@@ -17,7 +17,6 @@ public class EventPropagationPublisherOptionsValidatorTests
     [InlineData(null, null, null, false, false)]
     [InlineData(" ", "accessKey", "http://topicurl.com", false, false)]
     [InlineData(null, "accessKey", "http://topicurl.com", false, false)]
-    [InlineData("topicName", " ", "http://topicurl.com", false, false)]
     [InlineData("topicName", null, "http://topicurl.com", false, false)]
     [InlineData("topicName", "accessKey", " ", false, false)]
     [InlineData("topicName", "accessKey", null, false, false)]


### PR DESCRIPTION
## Context
As an IDP developer I want to have an unambiguous library.

Currently in the EventPropagation library, more specifically in the EventPropagationPublisherOptions class we have validation attributes on certain properties and also a validator class. It’s not a bad thing, but we could pick one or the other. We’ll pick to keep the validator class since what’s in there cannot be reproduced with the current attributes we have.

## What was done
- Move attributes validation from EventPropagationPublisherOptions to EventPropagationPublisherOptionsValidator
- Copy tests from EventPropagationPublisherOptionsTests to EventPropagationPublisherOptionsValidatorTests. Original tests were kept because they are validated through the service creation itself.
- ValidateDataAnnotation is removed from our extension method
- Remove GSoft.ComponentModel.DataAnnotations
- Remove Microsoft.Extensions.Options.DataAnnotations package