### PR TITLE
IDP-536 - Remove DataVersion field

### DIFF
--- a/src/Workleap.DomainEventPropagation.Abstractions/IDomainEvent.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/IDomainEvent.cs
@@ -2,5 +2,4 @@ namespace Workleap.DomainEventPropagation;
 
 public interface IDomainEvent
 {
-    string DataVersion { get; }
 }

--- a/src/Workleap.DomainEventPropagation.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Workleap.DomainEventPropagation.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+*REMOVED*Workleap.DomainEventPropagation.IDomainEvent.DataVersion.get -> string!

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
@@ -11,6 +11,7 @@ namespace Workleap.DomainEventPropagation;
 /// </summary>
 internal sealed class EventPropagationClient : IEventPropagationClient
 {
+    private const string DomainEventDefaultVersion = "1.0";
     private static readonly JsonSerializerOptions SerializerOptions = new();
 
     private readonly EventPropagationPublisherOptions _eventPropagationPublisherOptions;
@@ -59,7 +60,7 @@ internal sealed class EventPropagationClient : IEventPropagationClient
         return domainEvents.Select(domainEvent => new EventGridEvent(
             subject: $"{this.TopicName}-{typeof(T).FullName!}",
             eventType: domainEvent.GetType().AssemblyQualifiedName,
-            dataVersion: domainEvent.DataVersion,
+            dataVersion: DomainEventDefaultVersion,
             data: new BinaryData(domainEvent, SerializerOptions)));
     }
 }


### PR DESCRIPTION
## Context
As an IDP developer I want to remove any unnecessary field on public facing api so that devs are not confused.

We need to remove the DataVersion field on IDomainEvent interface, we talked with Julien and it’s not something that is used. We should just hardcode version 1.0 on events.

## What was done
- DataVersion was removed from IDomainEvent
- DataVersion was HardConded using a string constant with value 1.0
- Test was added to validate that all events are versio 1.0