### PR TITLE
IDP-573 - Fix nested activities

### DIFF
--- a/src/Workleap.DomainEventPropagation.Publishing/TracingPublishingDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/TracingPublishingDomainEventBehavior.cs
@@ -8,29 +8,26 @@ internal sealed class TracingPublishingDomainEventBehavior : IPublishingDomainEv
 {
     public Task HandleAsync(DomainEventWrapperCollection domainEventWrappers, DomainEventsHandlerDelegate next, CancellationToken cancellationToken)
     {
-        var activity = TracingHelper.StartProducerActivity(TracingHelper.EventGridEventsPublisherActivityName);
+        using var activity = TracingHelper.StartProducerActivity(TracingHelper.EventGridEventsPublisherActivityName);
         return activity == null ? next(domainEventWrappers, cancellationToken) : HandleWithTracing(domainEventWrappers, next, activity, cancellationToken);
     }
 
     private static async Task HandleWithTracing(DomainEventWrapperCollection domainEventWrappers, DomainEventsHandlerDelegate next, Activity activity, CancellationToken cancellationToken)
     {
-        using (activity)
+        activity.DisplayName = domainEventWrappers.DomainEventName;
+
+        try
         {
-            activity.DisplayName = domainEventWrappers.DomainEventName;
+            InjectCurrentActivityContextDataIntoEvents(domainEventWrappers);
 
-            try
-            {
-                InjectCurrentActivityContextDataIntoEvents(domainEventWrappers);
+            await next(domainEventWrappers, cancellationToken).ConfigureAwait(false);
 
-                await next(domainEventWrappers, cancellationToken).ConfigureAwait(false);
-
-                TracingHelper.MarkAsSuccessful(activity);
-            }
-            catch (Exception ex)
-            {
-                TracingHelper.MarkAsFailed(activity, ex);
-                throw;
-            }
+            TracingHelper.MarkAsSuccessful(activity);
+        }
+        catch (Exception ex)
+        {
+            TracingHelper.MarkAsFailed(activity, ex);
+            throw;
         }
     }
 


### PR DESCRIPTION
## Context
In terms of activity and tracing, we want to have each processed event to have the same parentId. That's not what was currently hapening. Currently every event would have the previous processed event as parent which would produce a trace similar to this:

```
|-- Received events
|    |-- Processing event A
|        |-- Processing event B 
```
But really what we want is something that looks like this:
```
|-- Received events
|    |-- Processing event A
|    |-- Processing event B 
```

## What changed
There seemed to be some problem with the disposal of the activity which was making it be referenced beyond it's using block and into the next processing block. In order to remedy this, the following changes were made:
- Moved using statement from HandleWithTracing to HandleAsync (This alone fixed the issue that could be clearly seen in Honeycomb for example)