### PR TITLE
IDP-573 - Change activity display name

### DIFF
--- a/src/Shared/InMemoryActivityTracker.cs
+++ b/src/Shared/InMemoryActivityTracker.cs
@@ -50,13 +50,13 @@ internal sealed class InMemoryActivityTracker : IDisposable
         }
     }
 
-    public void AssertPublishSuccessful()
+    public void AssertPublishSuccessful(string activityName)
     {
         lock (this._activitiesLock)
         {
-            var activity = Assert.Single(this._activities, activity => activity.OperationName == "EventGridEvents create");
+            var activity = Assert.Single(this._activities, activity => activity.OperationName == activityName);
 
-            Assert.Equal("EventGridEvents create", activity.OperationName);
+            Assert.Equal(activityName, activity.OperationName);
             Assert.Equal(ActivityKind.Producer, activity.Kind);
             Assert.Equal(ActivityStatusCode.Ok, activity.Status);
             Assert.Equal("OK", activity.GetTagItem(TracingHelper.StatusCodeTag));
@@ -69,7 +69,7 @@ internal sealed class InMemoryActivityTracker : IDisposable
         {
             var activity = Assert.Single(this._activities);
 
-            Assert.Equal("EventGridEvents create", activity.OperationName);
+            Assert.Equal(activityName, activity.OperationName);
             Assert.Equal(activityName, activity.DisplayName);
             Assert.Equal(ActivityKind.Producer, activity.Kind);
             Assert.Equal(ActivityStatusCode.Error, activity.Status);
@@ -84,13 +84,13 @@ internal sealed class InMemoryActivityTracker : IDisposable
         }
     }
 
-    public void AssertSubscribeSuccessful()
+    public void AssertSubscribeSuccessful(string activityName)
     {
         lock (this._activitiesLock)
         {
-            var activity = Assert.Single(this._activities, activity => activity.OperationName == "EventGridEvents process");
+            var activity = Assert.Single(this._activities, activity => activity.OperationName == activityName);
 
-            Assert.Equal("EventGridEvents process", activity.OperationName);
+            Assert.Equal(activityName, activity.OperationName);
             Assert.Equal(ActivityKind.Consumer, activity.Kind);
             Assert.Equal(ActivityStatusCode.Ok, activity.Status);
             Assert.Equal("OK", activity.GetTagItem(TracingHelper.StatusCodeTag));
@@ -103,8 +103,7 @@ internal sealed class InMemoryActivityTracker : IDisposable
         lock (this._activitiesLock)
         {
             var activity = Assert.Single(this._activities);
-
-            Assert.Equal("EventGridEvents process", activity.OperationName);
+            Assert.Equal(activityName, activity.OperationName);
             Assert.Equal(activityName, activity.DisplayName);
             Assert.Equal(ActivityKind.Consumer, activity.Kind);
             Assert.Equal(ActivityStatusCode.Error, activity.Status);

--- a/src/Shared/TelemetryClientExtensions.cs
+++ b/src/Shared/TelemetryClientExtensions.cs
@@ -7,7 +7,7 @@ namespace Workleap.DomainEventPropagation;
 
 internal static class TelemetryClientExtensions
 {
-    public static IOperationHolder<DependencyTelemetry> StartActivityAwareDependencyOperation(this TelemetryClient telemetryClient, string eventName)
+    public static IOperationHolder<DependencyTelemetry> StartActivityAwareDependencyOperation(this TelemetryClient telemetryClient, string activityName)
     {
         if (Activity.Current is { } activity && TracingHelper.IsEventGridActivity(activity))
         {
@@ -17,11 +17,11 @@ internal static class TelemetryClientExtensions
             // and bridge the gap between our activity, its own internal activity and the AI operation telemetry.
             // Not doing that could cause some Application Insights AND OpenTelemetry spans to be orphans.
             var operation = telemetryClient.StartOperation<DependencyTelemetry>(activity);
-            operation.Telemetry.Context.Operation.Name = eventName;
+            operation.Telemetry.Context.Operation.Name = activityName;
 
             return operation;
         }
 
-        return telemetryClient.StartOperation<DependencyTelemetry>(eventName);
+        return telemetryClient.StartOperation<DependencyTelemetry>(activityName);
     }
 }

--- a/src/Shared/TelemetryClientExtensions.cs
+++ b/src/Shared/TelemetryClientExtensions.cs
@@ -16,10 +16,7 @@ internal static class TelemetryClientExtensions
             // The Application Insights SDK will take care of populating the parent-child relationship
             // and bridge the gap between our activity, its own internal activity and the AI operation telemetry.
             // Not doing that could cause some Application Insights AND OpenTelemetry spans to be orphans.
-            var operation = telemetryClient.StartOperation<DependencyTelemetry>(activity);
-            operation.Telemetry.Context.Operation.Name = activityName;
-
-            return operation;
+            return telemetryClient.StartOperation<DependencyTelemetry>(activity);
         }
 
         return telemetryClient.StartOperation<DependencyTelemetry>(activityName);

--- a/src/Shared/TelemetryClientExtensions.cs
+++ b/src/Shared/TelemetryClientExtensions.cs
@@ -25,7 +25,7 @@ internal static class TelemetryClientExtensions
            operation = telemetryClient.StartOperation<DependencyTelemetry>(activityName);
         }
 
-        operation.Telemetry.Type = TracingHelper.EventGridEventsPublisherActivityType;
+        operation.Telemetry.Type = activityType;
 
         return operation;
     }

--- a/src/Shared/TelemetryClientExtensions.cs
+++ b/src/Shared/TelemetryClientExtensions.cs
@@ -7,8 +7,9 @@ namespace Workleap.DomainEventPropagation;
 
 internal static class TelemetryClientExtensions
 {
-    public static IOperationHolder<DependencyTelemetry> StartActivityAwareDependencyOperation(this TelemetryClient telemetryClient, string activityName)
+    public static IOperationHolder<DependencyTelemetry> StartActivityAwareDependencyOperation(this TelemetryClient telemetryClient, string activityName, string activityType)
     {
+        IOperationHolder<DependencyTelemetry> operation;
         if (Activity.Current is { } activity && TracingHelper.IsEventGridActivity(activity))
         {
             // When the current activity is our own Event Grid activity created in our previous event tracing behavior,
@@ -16,9 +17,16 @@ internal static class TelemetryClientExtensions
             // The Application Insights SDK will take care of populating the parent-child relationship
             // and bridge the gap between our activity, its own internal activity and the AI operation telemetry.
             // Not doing that could cause some Application Insights AND OpenTelemetry spans to be orphans.
-            return telemetryClient.StartOperation<DependencyTelemetry>(activity);
+            operation = telemetryClient.StartOperation<DependencyTelemetry>(activity);
+            operation.Telemetry.Name = activityName;
+        }
+        else
+        {
+           operation = telemetryClient.StartOperation<DependencyTelemetry>(activityName);
         }
 
-        return telemetryClient.StartOperation<DependencyTelemetry>(activityName);
+        operation.Telemetry.Type = TracingHelper.EventGridEventsPublisherActivityType;
+
+        return operation;
     }
 }

--- a/src/Shared/TracingHelper.cs
+++ b/src/Shared/TracingHelper.cs
@@ -16,8 +16,8 @@ internal static class TracingHelper
     internal const string ExceptionStackTraceTag = "exception.stacktrace";
 
     // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.18.0/specification/trace/semantic_conventions/cloudevents.md#conventions
-    internal const string EventGridEventsPublisherActivityName = "EventGridEvents create";
-    internal const string EventGridEventsSubscriberActivityName = "EventGridEvents process";
+    private const string EventGridEventsPublisherActivityName = "EventGridEvents create";
+    private const string EventGridEventsSubscriberActivityName = "EventGridEvents process";
 
     private static readonly Assembly Assembly = typeof(TracingHelper).Assembly;
     private static readonly AssemblyName AssemblyName = Assembly.GetName();
@@ -59,4 +59,8 @@ internal static class TracingHelper
     }
 
     public static bool IsEventGridActivity(Activity activity) => ActivitySource.Name == activity.Source.Name;
+
+    internal static string GetEventGridEventsPublisherActivityName(string eventType) => $"{EventGridEventsPublisherActivityName} {eventType}";
+
+    internal static string GetEventGridEventsSubscriberActivityName(string eventType) => $"{EventGridEventsSubscriberActivityName} {eventType}";
 }

--- a/src/Shared/TracingHelper.cs
+++ b/src/Shared/TracingHelper.cs
@@ -16,8 +16,8 @@ internal static class TracingHelper
     internal const string ExceptionStackTraceTag = "exception.stacktrace";
 
     // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.18.0/specification/trace/semantic_conventions/cloudevents.md#conventions
-    private const string EventGridEventsPublisherActivityName = "EventGridEvents create";
-    private const string EventGridEventsSubscriberActivityName = "EventGridEvents process";
+    internal const string EventGridEventsPublisherActivityType = "EventGridEvents create";
+    internal const string EventGridEventsSubscriberActivityType = "EventGridEvents process";
 
     private static readonly Assembly Assembly = typeof(TracingHelper).Assembly;
     private static readonly AssemblyName AssemblyName = Assembly.GetName();
@@ -60,7 +60,7 @@ internal static class TracingHelper
 
     public static bool IsEventGridActivity(Activity activity) => ActivitySource.Name == activity.Source.Name;
 
-    internal static string GetEventGridEventsPublisherActivityName(string eventType) => $"{EventGridEventsPublisherActivityName} {eventType}";
+    internal static string GetEventGridEventsPublisherActivityName(string eventType) => $"{EventGridEventsPublisherActivityType} {eventType}";
 
-    internal static string GetEventGridEventsSubscriberActivityName(string eventType) => $"{EventGridEventsSubscriberActivityName} {eventType}";
+    internal static string GetEventGridEventsSubscriberActivityName(string eventType) => $"{EventGridEventsSubscriberActivityType} {eventType}";
 }

--- a/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/ApplicationInsightsPublishingDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/ApplicationInsightsPublishingDomainEventBehavior.cs
@@ -21,7 +21,8 @@ internal sealed class ApplicationInsightsPublishingDomainEventBehavior : IPublis
 
     private async Task HandleWithTelemetry(DomainEventWrapperCollection domainEventWrappers, DomainEventsHandlerDelegate next, CancellationToken cancellationToken)
     {
-        var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(domainEventWrappers.DomainEventName);
+        var activityName = $"{TracingHelper.EventGridEventsPublisherActivityName} {domainEventWrappers.DomainEventName}";
+        var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(activityName);
 
         foreach (var domainEventWrapper in domainEventWrappers)
         {
@@ -34,7 +35,7 @@ internal sealed class ApplicationInsightsPublishingDomainEventBehavior : IPublis
 
         try
         {
-            operation.Telemetry.Name = TracingHelper.EventGridEventsPublisherActivityName;
+            operation.Telemetry.Name = activityName;
             operation.Telemetry.Type = ApplicationInsightsConstants.ProducerTelemetryKind;
 
             await next(domainEventWrappers, cancellationToken).ConfigureAwait(false);

--- a/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/ApplicationInsightsPublishingDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/ApplicationInsightsPublishingDomainEventBehavior.cs
@@ -21,8 +21,9 @@ internal sealed class ApplicationInsightsPublishingDomainEventBehavior : IPublis
 
     private async Task HandleWithTelemetry(DomainEventWrapperCollection domainEventWrappers, DomainEventsHandlerDelegate next, CancellationToken cancellationToken)
     {
-        var activityName = TracingHelper.GetEventGridEventsPublisherActivityName(domainEventWrappers.DomainEventName);
-        var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(activityName);
+        var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(
+            domainEventWrappers.DomainEventName,
+            TracingHelper.EventGridEventsPublisherActivityType);
 
         foreach (var domainEventWrapper in domainEventWrappers)
         {
@@ -35,9 +36,6 @@ internal sealed class ApplicationInsightsPublishingDomainEventBehavior : IPublis
 
         try
         {
-            operation.Telemetry.Name = domainEventWrappers.DomainEventName;
-            operation.Telemetry.Type = TracingHelper.EventGridEventsPublisherActivityType;
-
             await next(domainEventWrappers, cancellationToken).ConfigureAwait(false);
 
             operation.Telemetry.Success = true;

--- a/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/ApplicationInsightsPublishingDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/ApplicationInsightsPublishingDomainEventBehavior.cs
@@ -35,8 +35,8 @@ internal sealed class ApplicationInsightsPublishingDomainEventBehavior : IPublis
 
         try
         {
-            operation.Telemetry.Name = activityName;
-            operation.Telemetry.Type = ApplicationInsightsConstants.ProducerTelemetryKind;
+            operation.Telemetry.Name = domainEventWrappers.DomainEventName;
+            operation.Telemetry.Type = TracingHelper.EventGridEventsPublisherActivityType;
 
             await next(domainEventWrappers, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/ApplicationInsightsPublishingDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/ApplicationInsightsPublishingDomainEventBehavior.cs
@@ -21,7 +21,7 @@ internal sealed class ApplicationInsightsPublishingDomainEventBehavior : IPublis
 
     private async Task HandleWithTelemetry(DomainEventWrapperCollection domainEventWrappers, DomainEventsHandlerDelegate next, CancellationToken cancellationToken)
     {
-        var activityName = $"{TracingHelper.EventGridEventsPublisherActivityName} {domainEventWrappers.DomainEventName}";
+        var activityName = TracingHelper.GetEventGridEventsPublisherActivityName(domainEventWrappers.DomainEventName);
         var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(activityName);
 
         foreach (var domainEventWrapper in domainEventWrappers)

--- a/src/Workleap.DomainEventPropagation.Publishing.Tests/TracingBehaviorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing.Tests/TracingBehaviorTests.cs
@@ -22,7 +22,8 @@ public sealed class TracingBehaviorTests : BaseUnitTest<TracingBehaviorFixture>
         var domainEvent = new SampleDomainEvent();
         await this._eventPropagationClient.PublishDomainEventAsync(domainEvent, CancellationToken.None);
 
-        this._activities.AssertPublishSuccessful();
+        var activityName = TracingHelper.GetEventGridEventsPublisherActivityName("sample-event");
+        this._activities.AssertPublishSuccessful(activityName);
     }
 
     [Fact]
@@ -32,7 +33,8 @@ public sealed class TracingBehaviorTests : BaseUnitTest<TracingBehaviorFixture>
         var exception = await Assert.ThrowsAsync<EventPropagationPublishingException>(async () =>
             await this._eventPropagationClient.PublishDomainEventAsync(domainEvent, CancellationToken.None));
 
-        this._activities.AssertPublishFailed(nameof(ThrowingDomainEvent), exception.InnerException!);
+        var activityName = TracingHelper.GetEventGridEventsPublisherActivityName(nameof(ThrowingDomainEvent));
+        this._activities.AssertPublishFailed(activityName, exception.InnerException!);
     }
 
     [Fact]

--- a/src/Workleap.DomainEventPropagation.Publishing/TracingPublishingDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/TracingPublishingDomainEventBehavior.cs
@@ -22,7 +22,7 @@ internal sealed class TracingPublishingDomainEventBehavior : IPublishingDomainEv
 
     private static async Task HandleWithTracing(DomainEventWrapperCollection domainEventWrappers, DomainEventsHandlerDelegate next, Activity activity, CancellationToken cancellationToken)
     {
-        activity.DisplayName = domainEventWrappers.DomainEventName;
+        activity.DisplayName = $"{TracingHelper.EventGridEventsPublisherActivityName} {domainEventWrappers.DomainEventName}";
 
         try
         {

--- a/src/Workleap.DomainEventPropagation.Publishing/TracingPublishingDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/TracingPublishingDomainEventBehavior.cs
@@ -8,7 +8,9 @@ internal sealed class TracingPublishingDomainEventBehavior : IPublishingDomainEv
 {
     public async Task HandleAsync(DomainEventWrapperCollection domainEventWrappers, DomainEventsHandlerDelegate next, CancellationToken cancellationToken)
     {
-        using var activity = TracingHelper.StartProducerActivity(TracingHelper.EventGridEventsPublisherActivityName);
+        var activityName = TracingHelper.GetEventGridEventsPublisherActivityName(domainEventWrappers.DomainEventName);
+
+        using var activity = TracingHelper.StartProducerActivity(activityName);
 
         if (activity == null)
         {
@@ -22,8 +24,6 @@ internal sealed class TracingPublishingDomainEventBehavior : IPublishingDomainEv
 
     private static async Task HandleWithTracing(DomainEventWrapperCollection domainEventWrappers, DomainEventsHandlerDelegate next, Activity activity, CancellationToken cancellationToken)
     {
-        activity.DisplayName = $"{TracingHelper.EventGridEventsPublisherActivityName} {domainEventWrappers.DomainEventName}";
-
         try
         {
             InjectCurrentActivityContextDataIntoEvents(domainEventWrappers);

--- a/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
@@ -19,8 +19,9 @@ internal sealed class ApplicationInsightsSubscriptionDomainEventBehavior : ISubs
 
     private async Task HandleWithTelemetry(DomainEventWrapper domainEventWrapper, DomainEventHandlerDelegate next, CancellationToken cancellationToken)
     {
-        var activityName = TracingHelper.GetEventGridEventsSubscriberActivityName(domainEventWrapper.DomainEventName);
-        var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(activityName);
+        var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(
+            domainEventWrapper.DomainEventName,
+            TracingHelper.EventGridEventsSubscriberActivityType);
 
         if (domainEventWrapper.TryGetMetadata(ApplicationInsightsConstants.ParentOperationIdField, out var parentOperationId))
         {

--- a/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
@@ -19,7 +19,8 @@ internal sealed class ApplicationInsightsSubscriptionDomainEventBehavior : ISubs
 
     private async Task HandleWithTelemetry(DomainEventWrapper domainEventWrapper, DomainEventHandlerDelegate next, CancellationToken cancellationToken)
     {
-        var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(domainEventWrapper.DomainEventName);
+        var activityName = $"{TracingHelper.EventGridEventsSubscriberActivityName} {domainEventWrapper.DomainEventName}";
+        var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(activityName);
 
         if (domainEventWrapper.TryGetMetadata(ApplicationInsightsConstants.ParentOperationIdField, out var parentOperationId))
         {
@@ -35,7 +36,7 @@ internal sealed class ApplicationInsightsSubscriptionDomainEventBehavior : ISubs
 
         try
         {
-            operation.Telemetry.Name = TracingHelper.EventGridEventsSubscriberActivityName;
+            operation.Telemetry.Name = activityName;
             operation.Telemetry.Type = ApplicationInsightsConstants.ConsumerTelemetryKind;
 
             await next(domainEventWrapper, cancellationToken).ConfigureAwait(false);

--- a/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
@@ -36,8 +36,8 @@ internal sealed class ApplicationInsightsSubscriptionDomainEventBehavior : ISubs
 
         try
         {
-            operation.Telemetry.Name = activityName;
-            operation.Telemetry.Type = ApplicationInsightsConstants.ConsumerTelemetryKind;
+            operation.Telemetry.Name = domainEventWrapper.DomainEventName;
+            operation.Telemetry.Type = TracingHelper.EventGridEventsSubscriberActivityType;
 
             await next(domainEventWrapper, cancellationToken).ConfigureAwait(false);
 

--- a/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
@@ -19,7 +19,7 @@ internal sealed class ApplicationInsightsSubscriptionDomainEventBehavior : ISubs
 
     private async Task HandleWithTelemetry(DomainEventWrapper domainEventWrapper, DomainEventHandlerDelegate next, CancellationToken cancellationToken)
     {
-        var activityName = $"{TracingHelper.EventGridEventsSubscriberActivityName} {domainEventWrapper.DomainEventName}";
+        var activityName = TracingHelper.GetEventGridEventsSubscriberActivityName(domainEventWrapper.DomainEventName);
         var operation = this._telemetryClient!.StartActivityAwareDependencyOperation(activityName);
 
         if (domainEventWrapper.TryGetMetadata(ApplicationInsightsConstants.ParentOperationIdField, out var parentOperationId))

--- a/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/ApplicationInsightsSubscriptionDomainEventBehavior.cs
@@ -37,9 +37,6 @@ internal sealed class ApplicationInsightsSubscriptionDomainEventBehavior : ISubs
 
         try
         {
-            operation.Telemetry.Name = domainEventWrapper.DomainEventName;
-            operation.Telemetry.Type = TracingHelper.EventGridEventsSubscriberActivityType;
-
             await next(domainEventWrapper, cancellationToken).ConfigureAwait(false);
 
             operation.Telemetry.Success = true;

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/SampleDomainEvent.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/SampleDomainEvent.cs
@@ -1,6 +1,6 @@
 ﻿namespace Workleap.DomainEventPropagation.Subscription.Tests;
 
-[DomainEvent("sample")]
+[DomainEvent("sample-event")]
 public class SampleDomainEvent : IDomainEvent
 {
     public string? Message { get; set; }

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/TracingBehaviorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/TracingBehaviorTests.cs
@@ -28,7 +28,8 @@ public sealed class TracingBehaviorTests : BaseUnitTest<TracingBehaviorFixture>
         var domainEventGridWebhookHandler = new DomainEventGridWebhookHandler(this.Services, A.Fake<IDomainEventTypeRegistry>(), NullLogger<DomainEventGridWebhookHandler>.Instance, behaviors);
         await domainEventGridWebhookHandler.HandleEventGridWebhookEventAsync(eventGridEvent, CancellationToken.None);
 
-        this._activities.AssertSubscribeSuccessful();
+        var activityName = TracingHelper.GetEventGridEventsSubscriberActivityName(wrapperEvent.DomainEventName);
+        this._activities.AssertSubscribeSuccessful(activityName);
     }
 
     [Fact]
@@ -43,7 +44,8 @@ public sealed class TracingBehaviorTests : BaseUnitTest<TracingBehaviorFixture>
 
         var exception = await Assert.ThrowsAsync<Exception>(async () => await domainEventGridWebhookHandler.HandleEventGridWebhookEventAsync(eventGridEvent, CancellationToken.None));
 
-        this._activities.AssertSubscriptionFailed(wrapperEvent.DomainEventName, exception);
+        var activityName = TracingHelper.GetEventGridEventsSubscriberActivityName(wrapperEvent.DomainEventName);
+        this._activities.AssertSubscriptionFailed(activityName, exception);
     }
 
     [Fact]

--- a/src/Workleap.DomainEventPropagation.Subscription/TracingSubscriptionDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/TracingSubscriptionDomainEventBehavior.cs
@@ -32,7 +32,7 @@ internal sealed class TracingSubscriptionDomainEventBehavior : ISubscriptionDoma
 
     private static async Task HandleWithTracing(DomainEventWrapper domainEventWrapper, DomainEventHandlerDelegate next, Activity activity, CancellationToken cancellationToken)
     {
-        activity.DisplayName = domainEventWrapper.DomainEventName;
+        activity.DisplayName = $"{TracingHelper.EventGridEventsSubscriberActivityName} {domainEventWrapper.DomainEventName}";
 
         try
         {

--- a/src/Workleap.DomainEventPropagation.Subscription/TracingSubscriptionDomainEventBehavior.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/TracingSubscriptionDomainEventBehavior.cs
@@ -7,8 +7,10 @@ internal sealed class TracingSubscriptionDomainEventBehavior : ISubscriptionDoma
 {
     public async Task HandleAsync(DomainEventWrapper domainEventWrapper, DomainEventHandlerDelegate next, CancellationToken cancellationToken)
     {
+        var activityName = TracingHelper.GetEventGridEventsSubscriberActivityName(domainEventWrapper.DomainEventName);
         var propagationContext = ExtractPropagationContextFromEvent(domainEventWrapper);
-        using var activity = TracingHelper.StartConsumerActivity(TracingHelper.EventGridEventsSubscriberActivityName, propagationContext.ActivityContext);
+
+        using var activity = TracingHelper.StartConsumerActivity(activityName, propagationContext.ActivityContext);
 
         if (activity == null)
         {
@@ -32,8 +34,6 @@ internal sealed class TracingSubscriptionDomainEventBehavior : ISubscriptionDoma
 
     private static async Task HandleWithTracing(DomainEventWrapper domainEventWrapper, DomainEventHandlerDelegate next, Activity activity, CancellationToken cancellationToken)
     {
-        activity.DisplayName = $"{TracingHelper.EventGridEventsSubscriberActivityName} {domainEventWrapper.DomainEventName}";
-
         try
         {
             await next(domainEventWrapper, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Context
Given the cloud events [convention](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/cloudevents/cloudevents-spans.md#conventions), we want to have the event type exposed in an activity name. 

## What changed
- Modified the otel behaviors to display the event type name
- Modified the app insights behaviors to display the event type name