### PR TITLE
Add rule for attribute parameter

### DIFF
--- a/src/Workleap.DomainEventPropagation.Analyzers.Tests/EventDomainAttributeUsageAnalyzerTests.cs
+++ b/src/Workleap.DomainEventPropagation.Analyzers.Tests/EventDomainAttributeUsageAnalyzerTests.cs
@@ -21,7 +21,7 @@ public class SampleDomainEvent : IDomainEvent
     public async Task Given_DomainEventAttribute_When_Analyze_Then_No_Diagnostic()
     {
         const string source = @"
-[DomainEvent(""Sample"")]
+[DomainEvent(""SampleDomainEvent"")]
 public class SampleDomainEvent : IDomainEvent
 {    
 }";
@@ -34,7 +34,7 @@ public class SampleDomainEvent : IDomainEvent
     public async Task Given_Struct_With_DomainEventAttribute_When_Analyze_Then_No_Diagnostic()
     {
         const string source = @"
-[DomainEvent(""Sample"")]
+[DomainEvent(""SampleDomainEvent"")]
 public record SampleDomainEvent : IDomainEvent
 {    
 }";
@@ -74,8 +74,35 @@ public class SampleDomainEvent
     public async Task Given_DomainEventAttribute_With_Multiple_Attributes_When_Analyze_Then_No_Diagnostic()
     {
         const string source = @"
-[DomainEvent(""Sample"")]
+[DomainEvent(""SampleDomainEvent"")]
 [Serializable]
+public class SampleDomainEvent : IDomainEvent
+{    
+}";
+
+        await this.WithSourceCode(source)
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task Given_DomainEventAttribute_With_Wrong_Value_When_Analyze_Then_Diagnostic()
+    {
+        const string source = @"
+[DomainEvent(""Sample"")]
+public class SampleDomainEvent : IDomainEvent
+{    
+}";
+
+        await this.WithSourceCode(source)
+            .WithExpectedDiagnostic(EventDomainAttributeUsageAnalyzer.UseSameNameForAttributeValueAndClass, startLine: 3, startColumn: 14, endLine: 3, endColumn: 31, TestClassName)
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task Given_DomainEventAttribute_With_Right_Value_When_Analyze_Then_No_Diagnostic()
+    {
+        const string source = @"
+[DomainEvent(""SampleDomainEvent"")]
 public class SampleDomainEvent : IDomainEvent
 {    
 }";

--- a/src/Workleap.DomainEventPropagation.Analyzers/Internals/RuleIdentifiers.cs
+++ b/src/Workleap.DomainEventPropagation.Analyzers/Internals/RuleIdentifiers.cs
@@ -7,4 +7,6 @@ internal static class RuleIdentifiers
     // DO NOT change the identifier of existing rules.
     // Projects can customize the severity level of analysis rules using a .editorconfig file.
     public const string UseDomainEventAttribute = "WLDEP01";
+
+    public const string UseSameNameForAttributeValueAndClass = "WLDEP02";
 }


### PR DESCRIPTION
## Core changes

Added a rule to validate the naming of the Event.

## Screenshots

Example of error in a test project
![image](https://github.com/gsoft-inc/wl-domain-event-propagation/assets/295854/f7323b91-d1cf-4fdf-a3ce-7f221fa52226)

Performance of the analysers
![image](https://github.com/gsoft-inc/wl-domain-event-propagation/assets/295854/7f623b2c-3e52-4abf-9573-4cce753b8d4c)
