### PR TITLE
Updated Generic publication methods to force using a non-abstract eve…

### DIFF
--- a/src/Shared/DomainEventWrapper.cs
+++ b/src/Shared/DomainEventWrapper.cs
@@ -71,7 +71,7 @@ internal sealed class DomainEventWrapper
     }
 
     public static DomainEventWrapper Wrap<T>(T domainEvent)
-        where T : IDomainEvent
+        where T : IDomainEvent, new()
     {
         var domainEventName = DomainEventNameCache.GetName<T>();
         var domainEventSchema = DomainEventSchemaCache.GetEventSchema<T>();

--- a/src/Shared/DomainEventWrapperCollection.cs
+++ b/src/Shared/DomainEventWrapperCollection.cs
@@ -21,7 +21,7 @@ internal sealed class DomainEventWrapperCollection : IReadOnlyCollection<DomainE
     public EventSchema DomainSchema { get; }
 
     public static DomainEventWrapperCollection Create<T>(IEnumerable<T> domainEvents)
-        where T : IDomainEvent
+        where T : IDomainEvent, new()
     {
         var domainEventWrappers = domainEvents.Select(DomainEventWrapper.Wrap).ToArray();
         if (domainEventWrappers.Select(x => x.DomainEventName).Distinct().Count() > 1)

--- a/src/Workleap.DomainEventPropagation.Abstractions/DomainEventNameCache.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/DomainEventNameCache.cs
@@ -9,7 +9,7 @@ internal static class DomainEventNameCache
     private static readonly ConcurrentDictionary<Type, string> DomainEventNameTypeMappings = new ConcurrentDictionary<Type, string>();
 
     public static string GetName<T>()
-        where T : IDomainEvent
+        where T : IDomainEvent, new()
     {
         return GetName(typeof(T));
     }

--- a/src/Workleap.DomainEventPropagation.Abstractions/DomainEventSchemaCache.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/DomainEventSchemaCache.cs
@@ -9,7 +9,7 @@ internal static class DomainEventSchemaCache
     private static readonly ConcurrentDictionary<Type, EventSchema> DomainEventSchemaTypeMappings = new ConcurrentDictionary<Type, EventSchema>();
 
     public static EventSchema GetEventSchema<T>()
-        where T : IDomainEvent
+        where T : IDomainEvent, new()
     {
         return GetEventSchema(typeof(T));
     }

--- a/src/Workleap.DomainEventPropagation.Abstractions/IEventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/IEventPropagationClient.cs
@@ -3,8 +3,8 @@ namespace Workleap.DomainEventPropagation;
 public interface IEventPropagationClient
 {
     Task PublishDomainEventAsync<T>(T domainEvent, CancellationToken cancellationToken)
-        where T : IDomainEvent;
+        where T : IDomainEvent, new();
 
     Task PublishDomainEventsAsync<T>(IEnumerable<T> domainEvents, CancellationToken cancellationToken)
-        where T : IDomainEvent;
+        where T : IDomainEvent, new();
 }

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
@@ -31,11 +31,11 @@ internal sealed class EventPropagationClient : IEventPropagationClient
     }
 
     public Task PublishDomainEventAsync<T>(T domainEvent, CancellationToken cancellationToken)
-        where T : IDomainEvent
+        where T : IDomainEvent, new()
         => this.PublishDomainEventsAsync(new[] { domainEvent }, cancellationToken);
 
     public async Task PublishDomainEventsAsync<T>(IEnumerable<T> domainEvents, CancellationToken cancellationToken)
-        where T : IDomainEvent
+        where T : IDomainEvent, new()
     {
         if (domainEvents == null)
         {


### PR DESCRIPTION
## Description of changes
- Now forces consumer to give a concrete event : before, it was silently failing when we were wrapping the event (we proceed to a check that it's not abstract when wrapping it)

## Breaking changes
- Passing abstract events to publication methods will create a build-time error (instead of runtime)

- Will be done at the end - Updated the documentation of the project to reflect the changes
- N/A - Added new tests that cover the code changes
