### PR TITLE
Extracted registration functions and base methods from WebHook handler

### DIFF
--- a/src/Shared/BaseEventHandler.cs
+++ b/src/Shared/BaseEventHandler.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+
+namespace Workleap.DomainEventPropagation;
+
+internal abstract class BaseEventHandler
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IDomainEventTypeRegistry _domainEventTypeRegistry;
+
+    private static readonly ConcurrentDictionary<Type, MethodInfo> GenericDomainEventHandlerMethodCache = new();
+
+    protected BaseEventHandler(IServiceProvider serviceProvider, IDomainEventTypeRegistry domainEventTypeRegistry)
+    {
+        this._serviceProvider = serviceProvider;
+        this._domainEventTypeRegistry = domainEventTypeRegistry;
+    }
+
+    protected bool IsDomainEventRegistrationMissing(string eventName)
+    {
+        return this._domainEventTypeRegistry.GetDomainEventType(eventName) == null;
+    }
+
+    protected Func<Task>? BuildDomainEventHandler(DomainEventWrapper domainEventWrapper, CancellationToken cancellationToken)
+    {
+        var domainEventType = this._domainEventTypeRegistry.GetDomainEventType(domainEventWrapper.DomainEventName)!;
+        var domainEventHandlerType = this._domainEventTypeRegistry.GetDomainEventHandlerType(domainEventWrapper.DomainEventName)!;
+
+        var domainEventHandler = this._serviceProvider.GetService(domainEventHandlerType);
+        if (domainEventHandler == null)
+        {
+            return null;
+        }
+
+        var domainEvent = domainEventWrapper.Unwrap(domainEventType);
+
+        var domainEventHandlerMethod = GenericDomainEventHandlerMethodCache.GetOrAdd(domainEventHandlerType, type =>
+        {
+            const string handleDomainEventAsyncMethodName = "HandleDomainEventAsync";
+            return type.GetMethod(handleDomainEventAsyncMethodName, BindingFlags.Public | BindingFlags.Instance) ??
+                   throw new InvalidOperationException($"Public method {type.FullName}.{handleDomainEventAsyncMethodName} not found");
+        });
+
+        return () => (Task)domainEventHandlerMethod.Invoke(domainEventHandler, new[] { domainEvent, cancellationToken })!;
+    }
+}

--- a/src/Workleap.DomainEventPropagation.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/ServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Workleap.DomainEventPropagation;
+
+internal static class ServiceCollectionExtensions
+{
+    public static void AddDomainEventHandlers(this IServiceCollection services, IDomainEventTypeRegistry domainEventTypeRegistry, Assembly assembly)
+    {
+        if (assembly == null)
+        {
+            throw new ArgumentNullException(nameof(assembly));
+        }
+
+        var concreteHandlerTypes = assembly.GetTypes().Where(IsConcreteDomainEventHandlerType);
+
+        foreach (var concreteHandlerType in concreteHandlerTypes)
+        {
+            AddHandler(services, domainEventTypeRegistry, concreteHandlerType);
+        }
+    }
+
+    public static void AddDomainEventHandler<TEvent, THandler>(this IServiceCollection services, IDomainEventTypeRegistry domainEventTypeRegistry)
+        where THandler : IDomainEventHandler<TEvent>
+        where TEvent : IDomainEvent
+    {
+        AddHandler(services, domainEventTypeRegistry, typeof(THandler));
+    }
+
+    private static bool IsConcreteDomainEventHandlerType(Type type)
+    {
+        return !type.IsAbstract && type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDomainEventHandler<>));
+    }
+
+    private static void AddHandler(IServiceCollection services, IDomainEventTypeRegistry domainEventTypeRegistry, Type concreteHandlerType)
+    {
+        foreach (var handlerInterfaceType in FindGenericDomainEventHandlerInterfaces(concreteHandlerType))
+        {
+            var domainEventType = handlerInterfaceType.GenericTypeArguments[0];
+            domainEventTypeRegistry.RegisterDomainEvent(domainEventType);
+            services.TryAddTransient(handlerInterfaceType, concreteHandlerType);
+        }
+    }
+
+    private static IEnumerable<Type> FindGenericDomainEventHandlerInterfaces(Type handlerType)
+    {
+        return handlerType.FindInterfaces(FilterGenericInterfaceOf, typeof(IDomainEventHandler<>));
+
+        static bool FilterGenericInterfaceOf(Type interfaceType, object? criteria)
+        {
+            return interfaceType.IsGenericType && ReferenceEquals(interfaceType.GetGenericTypeDefinition(), criteria);
+        }
+    }
+}

--- a/src/Workleap.DomainEventPropagation.Abstractions/Workleap.DomainEventPropagation.Abstractions.csproj
+++ b/src/Workleap.DomainEventPropagation.Abstractions/Workleap.DomainEventPropagation.Abstractions.csproj
@@ -36,6 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Workleap.DomainEventPropagation.Subscription/DomainEventGridWebhookHandler.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/DomainEventGridWebhookHandler.cs
@@ -1,16 +1,10 @@
-using System.Collections.Concurrent;
-using System.Reflection;
 using Azure.Messaging.EventGrid;
 using Microsoft.Extensions.Logging;
 
 namespace Workleap.DomainEventPropagation;
 
-internal sealed class DomainEventGridWebhookHandler : IDomainEventGridWebhookHandler
+internal sealed class DomainEventGridWebhookHandler : BaseEventHandler, IDomainEventGridWebhookHandler
 {
-    private static readonly ConcurrentDictionary<Type, MethodInfo> GenericDomainEventHandlerMethodCache = new ConcurrentDictionary<Type, MethodInfo>();
-
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IDomainEventTypeRegistry _domainEventTypeRegistry;
     private readonly ILogger<DomainEventGridWebhookHandler> _logger;
     private readonly DomainEventHandlerDelegate _pipeline;
 
@@ -19,24 +13,17 @@ internal sealed class DomainEventGridWebhookHandler : IDomainEventGridWebhookHan
         IDomainEventTypeRegistry domainEventTypeRegistry,
         ILogger<DomainEventGridWebhookHandler> logger,
         IEnumerable<ISubscriptionDomainEventBehavior> subscriptionDomainEventBehaviors)
+        : base(serviceProvider, domainEventTypeRegistry)
     {
-        this._serviceProvider = serviceProvider;
-        this._domainEventTypeRegistry = domainEventTypeRegistry;
         this._logger = logger;
         this._pipeline = subscriptionDomainEventBehaviors.Reverse().Aggregate((DomainEventHandlerDelegate)this.HandleDomainEventAsync, BuildPipeline);
-    }
-
-    private static DomainEventHandlerDelegate BuildPipeline(DomainEventHandlerDelegate next, ISubscriptionDomainEventBehavior pipeline)
-    {
-        return (events, cancellationToken) => pipeline.HandleAsync(events, next, cancellationToken);
     }
 
     public async Task HandleEventGridWebhookEventAsync(EventGridEvent eventGridEvent, CancellationToken cancellationToken)
     {
         var domainEventWrapper = new DomainEventWrapper(eventGridEvent);
 
-        var isDomainEventTypeUnknown = this._domainEventTypeRegistry.GetDomainEventType(domainEventWrapper.DomainEventName) == null;
-        if (isDomainEventTypeUnknown)
+        if (this.IsDomainEventRegistrationMissing(domainEventWrapper.DomainEventName))
         {
             this._logger.EventDomainTypeNotRegistered(domainEventWrapper.DomainEventName, eventGridEvent.Subject);
             return;
@@ -45,27 +32,20 @@ internal sealed class DomainEventGridWebhookHandler : IDomainEventGridWebhookHan
         await this._pipeline(domainEventWrapper, cancellationToken).ConfigureAwait(false);
     }
 
+    private static DomainEventHandlerDelegate BuildPipeline(DomainEventHandlerDelegate next, ISubscriptionDomainEventBehavior pipeline)
+    {
+        return (events, cancellationToken) => pipeline.HandleAsync(events, next, cancellationToken);
+    }
+
     private async Task HandleDomainEventAsync(DomainEventWrapper domainEventWrapper, CancellationToken cancellationToken)
     {
-        var domainEventType = this._domainEventTypeRegistry.GetDomainEventType(domainEventWrapper.DomainEventName)!;
-        var domainEventHandlerType = this._domainEventTypeRegistry.GetDomainEventHandlerType(domainEventWrapper.DomainEventName)!;
-
-        var domainEventHandler = this._serviceProvider.GetService(domainEventHandlerType);
-        if (domainEventHandler == null)
+        var handler = this.BuildDomainEventHandler(domainEventWrapper, cancellationToken);
+        if (handler == null)
         {
             this._logger.EventDomainHandlerNotRegistered(domainEventWrapper.DomainEventName);
             return;
         }
 
-        var domainEvent = domainEventWrapper.Unwrap(domainEventType);
-
-        var domainEventHandlerMethod = GenericDomainEventHandlerMethodCache.GetOrAdd(domainEventHandlerType, type =>
-        {
-            const string handleDomainEventAsyncMethodName = "HandleDomainEventAsync";
-            return type.GetMethod(handleDomainEventAsyncMethodName, BindingFlags.Public | BindingFlags.Instance) ??
-                throw new InvalidOperationException($"Public method {type.FullName}.{handleDomainEventAsyncMethodName} not found");
-        });
-
-        await ((Task)domainEventHandlerMethod.Invoke(domainEventHandler, new[] { domainEvent, cancellationToken })!).ConfigureAwait(false);
+        await handler().ConfigureAwait(false);
     }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription/EventPropagationSubscriberBuilder.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/EventPropagationSubscriberBuilder.cs
@@ -30,51 +30,15 @@ internal sealed class EventPropagationSubscriberBuilder : IEventPropagationSubsc
 
     public IEventPropagationSubscriberBuilder AddDomainEventHandlers(Assembly assembly)
     {
-        if (assembly == null)
-        {
-            throw new ArgumentNullException(nameof(assembly));
-        }
-
-        var concreteHandlerTypes = assembly.GetTypes().Where(IsConcreteDomainEventHandlerType);
-
-        foreach (var concreteHandlerType in concreteHandlerTypes)
-        {
-            this.AddHandler(concreteHandlerType);
-        }
-
+        this.Services.AddDomainEventHandlers(this._domainEventTypeRegistry, assembly);
         return this;
-    }
-
-    private static bool IsConcreteDomainEventHandlerType(Type type)
-    {
-        return !type.IsAbstract && type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDomainEventHandler<>));
     }
 
     public IEventPropagationSubscriberBuilder AddDomainEventHandler<TEvent, THandler>()
         where THandler : IDomainEventHandler<TEvent>
         where TEvent : IDomainEvent
     {
-        this.AddHandler(typeof(THandler));
+        this.Services.AddDomainEventHandler<TEvent, THandler>(this._domainEventTypeRegistry);
         return this;
-    }
-
-    private void AddHandler(Type concreteHandlerType)
-    {
-        foreach (var handlerInterfaceType in FindGenericDomainEventHandlerInterfaces(concreteHandlerType))
-        {
-            var domainEventType = handlerInterfaceType.GenericTypeArguments[0];
-            this._domainEventTypeRegistry.RegisterDomainEvent(domainEventType);
-            this.Services.TryAddTransient(handlerInterfaceType, concreteHandlerType);
-        }
-    }
-
-    private static IEnumerable<Type> FindGenericDomainEventHandlerInterfaces(Type handlerType)
-    {
-        return handlerType.FindInterfaces(FilterGenericInterfaceOf, typeof(IDomainEventHandler<>));
-
-        static bool FilterGenericInterfaceOf(Type interfaceType, object? criteria)
-        {
-            return interfaceType.IsGenericType && ReferenceEquals(interfaceType.GetGenericTypeDefinition(), criteria);
-        }
     }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription/Workleap.DomainEventPropagation.Subscription.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription/Workleap.DomainEventPropagation.Subscription.csproj
@@ -41,6 +41,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\BaseEventHandler.cs">
+      <Link>Shared\BaseEventHandler.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\DomainEventWrapper.cs" Link="Shared\DomainEventWrapper.cs" />
     <Compile Include="..\Shared\TracingHelper.cs" Link="Shared\TracingHelper.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Description of changes
To add support for Cloud Events with pull model, we need to duplicate a lot of the logic used within the DomainEventGridWebhookHandler
- Extracted logic that need to be reused within a base class
- Extracted registration logic in extension methods

## Breaking changes
None, public API did not changed

## Additional checks
- [ ] N/A - Usage did not changed
- [x] Added new tests that cover the code changes
