### PR TITLE
[IDP-902] feat(fix): address initial comments for #104

### DIFF
--- a/src/Shared/DomainEventWrapperCollection.cs
+++ b/src/Shared/DomainEventWrapperCollection.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace Workleap.DomainEventPropagation;
 

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherBuilder.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherBuilder.cs
@@ -31,7 +31,7 @@ internal sealed class EventPropagationPublisherBuilder : IEventPropagationPublis
         this.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<EventPropagationPublisherOptions>, EventPropagationPublisherOptionsValidator>());
         this.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPublishingDomainEventBehavior, TracingPublishingDomainEventBehavior>());
 
-        this.Services.AddAzureClients(ConfigureEventPublisher);
+        this.Services.AddAzureClients(ConfigureEventPublisherClients);
     }
 
     private static void BindFromWellKnownConfigurationSection(EventPropagationPublisherOptions options, IConfiguration configuration)
@@ -39,7 +39,7 @@ internal sealed class EventPropagationPublisherBuilder : IEventPropagationPublis
         configuration.GetSection(EventPropagationPublisherOptions.SectionName).Bind(options);
     }
 
-    private static void ConfigureEventPublisher(AzureClientFactoryBuilder builder)
+    private static void ConfigureEventPublisherClients(AzureClientFactoryBuilder builder)
     {
         builder.AddClient<EventGridPublisherClient, EventGridPublisherClientOptions>(EventGridPublisherClientFactory)
             .WithName(EventPropagationPublisherOptions.CustomTopicClientName)

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/CloudEventHandlerUnitTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/CloudEventHandlerUnitTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using Azure.Messaging;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -34,7 +33,7 @@ public class CloudEventHandlerUnitTests
         var result = await handler.HandleCloudEventAsync(cloudEvent, CancellationToken.None);
 
         // Then
-        result.Should().Be(EventProcessingStatus.Rejected);
+        Assert.Equal(EventProcessingStatus.Rejected, result);
     }
 
     [Fact]
@@ -50,7 +49,7 @@ public class CloudEventHandlerUnitTests
         var result = await handler.HandleCloudEventAsync(cloudEvent, CancellationToken.None);
 
         // Then
-        result.Should().Be(EventProcessingStatus.Rejected);
+        Assert.Equal(EventProcessingStatus.Rejected, result);
     }
 
     [Fact]
@@ -69,7 +68,7 @@ public class CloudEventHandlerUnitTests
         var result = await handler.HandleCloudEventAsync(cloudEvent, CancellationToken.None);
 
         // Then
-        result.Should().Be(EventProcessingStatus.Rejected);
+        Assert.Equal(EventProcessingStatus.Rejected, result);
     }
 
     [Fact]
@@ -92,7 +91,7 @@ public class CloudEventHandlerUnitTests
         var result = await handler.HandleCloudEventAsync(cloudEvent, CancellationToken.None);
 
         // Then
-        result.Should().Be(EventProcessingStatus.Released);
+        Assert.Equal(EventProcessingStatus.Released, result);
     }
 
     [Fact]
@@ -112,8 +111,9 @@ public class CloudEventHandlerUnitTests
         var result = await handler.HandleCloudEventAsync(cloudEvent, CancellationToken.None);
 
         // Then
-        SampleEventTestHandler.ReceivedEvents.Should().Contain(e => e.Message == eventMessage);
-        result.Should().Be(EventProcessingStatus.Handled);
+        Assert.Single(SampleEventTestHandler.ReceivedEvents, e => e.Message == eventMessage);
+        
+        Assert.Equal(EventProcessingStatus.Handled, result);
     }
 
     [Fact]
@@ -133,8 +133,9 @@ public class CloudEventHandlerUnitTests
         var result = await handler.HandleCloudEventAsync(cloudEvent, CancellationToken.None);
 
         // Then
-        SampleEventTestHandler.ReceivedEvents.Should().Contain(e => e.Message == eventMessage);
-        result.Should().Be(EventProcessingStatus.Handled);
+        Assert.Single(SampleEventTestHandler.ReceivedEvents, e => e.Message == eventMessage);
+        
+        Assert.Equal(EventProcessingStatus.Handled, result);
     }
 
     private static CloudEvent GivenSampleEvent(string message = "Hello World!")

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPullerTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPullerTests.cs
@@ -1,4 +1,4 @@
-﻿using AutoBogus;
+using AutoBogus;
 using Azure.Messaging;
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Workleap.DomainEventPropagation.EventGridClientAdapter;
+using Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.TestExtensions;
 
 namespace Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests;
 
@@ -49,11 +50,9 @@ public class EventPullerTests
 
     private static async Task StartWaitAndStop(IHostedService puller)
     {
-// We need this to start on the thread pool otherwise it will just block the test
-#pragma warning disable CS4014
-        Task.Run(() => puller.StartAsync(CancellationToken.None));
+        // We need this to start on the thread pool otherwise it will just block the test
+        Task.Run(() => puller.StartAsync(CancellationToken.None)).Forget();
         await Task.Delay(50);
-#pragma warning restore CS4014
         await puller.StopAsync(CancellationToken.None);
     }
 

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPullerTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPullerTests.cs
@@ -10,10 +10,7 @@ using Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.TestExtens
 
 namespace Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests;
 
-// Test class cannot be made static
-#pragma warning disable CA1052
-public class EventPullerTests
-#pragma warning restore CA1052
+public abstract class EventPullerTests
 {
     private static IEventGridClientAdapter GivenFakeClient(IEventGridClientWrapperFactory clientWrapperFactory, string subName)
     {

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/ServiceCollectionEventSubscriptionExtensionsTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/ServiceCollectionEventSubscriptionExtensionsTests.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using Azure.Messaging.EventGrid.Namespaces;
 using FakeItEasy;
-using FluentAssertions;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -117,8 +116,9 @@ public class ServiceCollectionEventSubscriptionExtensionsTests
         var clientDescriptors = serviceProvider.GetRequiredService<IEnumerable<EventGridClientDescriptor>>().ToArray();
 
         // Then
-        clientDescriptors.Should().HaveCount(2);
-        clientDescriptors.Select(d => d.Name).Should().BeEquivalentTo(sectionName1, sectionName2);
+        Assert.Equal(2, clientDescriptors.Length);
+        
+        Assert.True(clientDescriptors.Select(d => d.Name).SequenceEqual([sectionName1, sectionName2]));
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class ServiceCollectionEventSubscriptionExtensionsTests
             .AddDomainEventHandler<SampleEvent, SampleEventTestHandler>();
 
         // Then
-        act.Should().Throw<InvalidOperationException>();
+        Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class ServiceCollectionEventSubscriptionExtensionsTests
             .AddDomainEventHandlers(Assembly.GetAssembly(typeof(ServiceCollectionEventSubscriptionExtensionsTests))!);
 
         // Then
-        act.Should().Throw<InvalidOperationException>();
+        Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
@@ -181,13 +181,13 @@ public class ServiceCollectionEventSubscriptionExtensionsTests
         var services = new ServiceCollection();
 
         // When
-        var fct = () => services.AddPullDeliverySubscription()
+        var act = () => services.AddPullDeliverySubscription()
             .AddTopicSubscription()
             .AddDomainEventHandler<MisconfiguredTestAssembly.SampleEvent, MisconfiguredTestAssembly.SampleEventTestHandler>()
             .AddDomainEventHandler<MisconfiguredTestAssembly.SampleEvent, MisconfiguredTestAssembly.AnotherSampleEventTestHandler>();
 
         // Then
-        fct.Should().Throw<InvalidOperationException>();
+        Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
@@ -197,13 +197,13 @@ public class ServiceCollectionEventSubscriptionExtensionsTests
         var services = new ServiceCollection();
 
         // When
-        var fct = () => services.AddPullDeliverySubscription()
+        var act = () => services.AddPullDeliverySubscription()
             .AddTopicSubscription()
             .AddDomainEventHandler<SampleEvent, SampleEventTestHandler>()
             .AddDomainEventHandlers(Assembly.GetAssembly(typeof(ServiceCollectionEventSubscriptionExtensionsTests))!);
 
         // Then
-        fct.Should().Throw<InvalidOperationException>();
+        Assert.Throws<InvalidOperationException>(act);
     }
 
     [Fact]
@@ -217,7 +217,7 @@ public class ServiceCollectionEventSubscriptionExtensionsTests
             .AddDomainEventHandlers(Assembly.GetAssembly(typeof(MisconfiguredTestAssembly.SampleEvent))!);
 
         // Then
-        act.Should().Throw<InvalidOperationException>();
+        Assert.Throws<InvalidOperationException>(act);
     }
 
     private static void GivenConfigurations(IServiceCollection services, params string[] sections)

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/ServiceCollectionEventSubscriptionExtensionsTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/ServiceCollectionEventSubscriptionExtensionsTests.cs
@@ -131,7 +131,7 @@ public class ServiceCollectionEventSubscriptionExtensionsTests
         GivenConfigurations(services, sectionName1, sectionName2);
         var fakeClientFactory = A.Fake<IAzureClientFactory<EventGridClient>>();
         services.Replace(new ServiceDescriptor(typeof(IAzureClientFactory<EventGridClient>), fakeClientFactory));
-        services.AddTransient<ILogger<EventPuller>, NullLogger<EventPuller>>();
+        services.AddTransient<ILogger<EventPullerService>, NullLogger<EventPullerService>>();
         services.AddTransient<ILogger<ICloudEventHandler>, NullLogger<ICloudEventHandler>>();
 
         // When

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/TestExtensions/TaskExtensions.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/TestExtensions/TaskExtensions.cs
@@ -1,0 +1,38 @@
+namespace Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.TestExtensions;
+
+internal static class TaskExtensions
+{
+    /// <summary>
+    /// Observes the task to avoid the UnobservedTaskException event to be raised.
+    /// </summary>
+    /// <remarks>
+    /// Inspired from <see href="https://www.meziantou.net/fire-and-forget-a-task-in-dotnet.htm">this blog post</see>
+    /// </remarks>
+    public static void Forget(this Task task)
+    {
+        // note: this code is inspired by a tweet from Ben Adams: https://twitter.com/ben_a_adams/status/1045060828700037125
+        // Only care about tasks that may fault (not completed) or are faulted,
+        // so fast-path for SuccessfullyCompleted and Canceled tasks.
+        if (!task.IsCompleted || task.IsFaulted)
+        {
+            // use "_" (Discard operation) to remove the warning IDE0058: Because this call is not awaited, execution of the current method continues before the call is completed
+            // https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards?WT.mc_id=DT-MVP-5003978#a-standalone-discard
+            _ = ForgetAwaited(task);
+        }
+
+        // Allocate the async/await state machine only when needed for performance reasons.
+        // More info about the state machine: https://blogs.msdn.microsoft.com/seteplia/2017/11/30/dissecting-the-async-methods-in-c/?WT.mc_id=DT-MVP-5003978
+        static async Task ForgetAwaited(Task task)
+        {
+            try
+            {
+                // No need to resume on the original SynchronizationContext, so use ConfigureAwait(false)
+                await task.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Nothing to do here
+            }
+        }
+    }
+}

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="AutoBogus" Version="2.13.1" />
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="GSoft.Extensions.Xunit" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.20" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/IEventGridClientAdapter.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/IEventGridClientAdapter.cs
@@ -1,6 +1,4 @@
-﻿using Azure.Messaging.EventGrid.Namespaces;
-
-namespace Workleap.DomainEventPropagation.EventGridClientAdapter;
+﻿namespace Workleap.DomainEventPropagation.EventGridClientAdapter;
 
 internal interface IEventGridClientAdapter
 {

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriberBuilder.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriberBuilder.cs
@@ -27,7 +27,7 @@ internal sealed class EventPropagationSubscriberBuilder : IEventPropagationSubsc
 
         this.Services.AddTransient<IEventGridClientWrapperFactory, EventGridClientAdapterFactory>();
         this.Services.AddTransient<ICloudEventHandler, CloudEventHandler>();
-        this.Services.AddHostedService<EventPuller>();
+        this.Services.AddHostedService<EventPullerService>();
     }
 
     public IServiceCollection Services { get; }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -6,18 +6,18 @@ using Workleap.DomainEventPropagation.EventGridClientAdapter;
 
 namespace Workleap.DomainEventPropagation;
 
-internal class EventPuller : BackgroundService
+internal class EventPullerService : BackgroundService
 {
     private readonly IServiceScopeFactory _serviceScopeFactory;
-    private readonly ILogger<EventPuller> _logger;
+    private readonly ILogger<EventPullerService> _logger;
     private readonly EventGridTopicSubscription[] _eventGridTopicSubscriptions;
 
-    public EventPuller(
+    public EventPullerService(
         IServiceScopeFactory serviceScopeFactory,
         IEnumerable<EventGridClientDescriptor> clientDescriptors,
         IEventGridClientWrapperFactory eventGridClientWrapperFactory,
         IOptionsMonitor<EventPropagationSubscriptionOptions> optionsMonitor,
-        ILogger<EventPuller> logger)
+        ILogger<EventPullerService> logger)
     {
         this._serviceScopeFactory = serviceScopeFactory;
         this._logger = logger;
@@ -33,7 +33,7 @@ internal class EventPuller : BackgroundService
         return Task.WhenAll(this._eventGridTopicSubscriptions.Select(sub => Task.Run(() => this.StartReceivingEventsAsync(sub, this._logger, stoppingToken), stoppingToken)));
     }
 
-    private async Task StartReceivingEventsAsync(EventGridTopicSubscription eventGridTopicSubscription, ILogger<EventPuller> logger, CancellationToken stoppingToken)
+    private async Task StartReceivingEventsAsync(EventGridTopicSubscription eventGridTopicSubscription, ILogger<EventPullerService> logger, CancellationToken stoppingToken)
     {
         using var scope = this._serviceScopeFactory.CreateScope();
         var cloudEventHandler = scope.ServiceProvider.GetRequiredService<ICloudEventHandler>();

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiIntegrationTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiIntegrationTests.cs
@@ -1,7 +1,5 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Net.Mime;
-using System.Text;
 using System.Text.Json;
 using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventGrid.SystemEvents;


### PR DESCRIPTION
This is an initial pass at fixing comments for #104.

It mostly consists of:
- cleanup `using` statements
- remove `#pragma warning` when applicable
- rename abstractions, methods, etc

For tests, we've also adapted tests to use xUnit's assertions rather than `FluentAssertions`.