### PR TITLE
[IDP-990] Run our tests with Activities sequentially to avoid test flakiness

### DIFF
--- a/src/Shared/XunitCollectionConstants.cs
+++ b/src/Shared/XunitCollectionConstants.cs
@@ -1,0 +1,6 @@
+namespace Workleap.DomainEventPropagation.Tests;
+
+public static class XunitCollectionConstants
+{
+    public const string StaticActivitySensitive = "activity";
+}

--- a/src/Workleap.DomainEventPropagation.Publishing.Tests/TracingBehaviorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing.Tests/TracingBehaviorTests.cs
@@ -4,6 +4,7 @@ using Workleap.DomainEventPropagation.Tests;
 
 namespace Workleap.DomainEventPropagation.Publishing.Tests;
 
+[Collection(XunitCollectionConstants.StaticActivitySensitive)]
 public sealed class TracingBehaviorTests : BaseUnitTest<TracingBehaviorFixture>
 {
     private readonly InMemoryActivityTracker _activities;

--- a/src/Workleap.DomainEventPropagation.Publishing.Tests/Workleap.DomainEventPropagation.Publishing.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing.Tests/Workleap.DomainEventPropagation.Publishing.Tests.csproj
@@ -31,5 +31,8 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\InMemoryActivityTracker.cs" Link="Shared\InMemoryActivityTracker.cs" />
+    <Compile Include="..\Shared\XunitCollectionConstants.cs">
+      <Link>Shared\XunitCollectionConstants.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiIntegrationTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiIntegrationTests.cs
@@ -1,7 +1,5 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Net.Mime;
-using System.Text;
 using System.Text.Json;
 using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventGrid.SystemEvents;
@@ -12,9 +10,11 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Workleap.DomainEventPropagation.Tests;
 
 namespace Workleap.DomainEventPropagation.Subscription.Tests.Apis;
 
+[Collection(XunitCollectionConstants.StaticActivitySensitive)]
 public class EventsApiIntegrationTests : IClassFixture<EventsApiIntegrationTestsFixture>
 {
     private readonly HttpClient _httpClient;

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/TracingBehaviorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/TracingBehaviorTests.cs
@@ -3,10 +3,12 @@ using FakeItEasy;
 using GSoft.Extensions.Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Workleap.DomainEventPropagation.Publishing.Tests;
 using Workleap.DomainEventPropagation.Tests;
 
 namespace Workleap.DomainEventPropagation.Subscription.Tests;
 
+[Collection(XunitCollectionConstants.StaticActivitySensitive)]
 public sealed class TracingBehaviorTests : BaseUnitTest<TracingBehaviorFixture>
 {
     private readonly InMemoryActivityTracker _activities;

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Workleap.DomainEventPropagation.Subscription.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Workleap.DomainEventPropagation.Subscription.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Workleap.DomainEventPropagation.Publishing.Tests\Workleap.DomainEventPropagation.Publishing.Tests.csproj" />
     <ProjectReference Include="..\Workleap.DomainEventPropagation.Subscription.ApplicationInsights\Workleap.DomainEventPropagation.Subscription.ApplicationInsights.csproj" />
     <ProjectReference Include="..\Workleap.DomainEventPropagation.Subscription\Workleap.DomainEventPropagation.Subscription.csproj" />
   </ItemGroup>
@@ -31,5 +32,8 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\InMemoryActivityTracker.cs" Link="Shared\InMemoryActivityTracker.cs" />
+    <Compile Include="..\Shared\XunitCollectionConstants.cs">
+      <Link>Shared\XunitCollectionConstants.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description of changes
We are running into test flakiness when executing multiple tests in parallel. This is caused by the `InMemoryActivityTracker` being static, so states can leak between test executions. That leak is causing our tests to fail due to flakiness. The solution is run these tests in a sequential fashion as part of a collection.

## Breaking changes
None.

## Additional checks
Verify that tests are no longer flaky.

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
