### PR TITLE
[IDP-990] Run our tests with Activities sequentially to avoid test flakiness

### DIFF
--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiIntegrationTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiIntegrationTests.cs
@@ -1,7 +1,5 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Net.Mime;
-using System.Text;
 using System.Text.Json;
 using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventGrid.SystemEvents;
@@ -15,6 +13,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace Workleap.DomainEventPropagation.Subscription.Tests.Apis;
 
+[Collection(XunitCollectionConstants.StaticActivitySensitive)]
 public class EventsApiIntegrationTests : IClassFixture<EventsApiIntegrationTestsFixture>
 {
     private readonly HttpClient _httpClient;

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/TracingBehaviorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/TracingBehaviorTests.cs
@@ -7,6 +7,7 @@ using Workleap.DomainEventPropagation.Tests;
 
 namespace Workleap.DomainEventPropagation.Subscription.Tests;
 
+[Collection(XunitCollectionConstants.StaticActivitySensitive)]
 public sealed class TracingBehaviorTests : BaseUnitTest<TracingBehaviorFixture>
 {
     private readonly InMemoryActivityTracker _activities;

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/XunitCollectionConstants.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/XunitCollectionConstants.cs
@@ -1,0 +1,6 @@
+namespace Workleap.DomainEventPropagation.Subscription.Tests;
+
+public static class XunitCollectionConstants
+{
+    public const string StaticActivitySensitive = "activity";
+}


### PR DESCRIPTION
## Description of changes
We are running into test flakiness when executing multiple tests in parallel. This is caused by the `InMemoryActivityTracker` being static, so states can leak between test executions. That leak is causing our tests to fail due to flakiness. The solution is run these tests in a sequential fashion as part of a collection.

## Breaking changes
None.

## Additional checks
Verify that tests are no longer flaky.

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
