### PR TITLE
[IDP-902] deps: use non-vulnerable version for Azure.Identity

### DIFF
--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoBogus" Version="2.13.1" />
-    <PackageReference Include="Azure.Identity" Version="1.7.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
     <PackageReference Include="GSoft.Extensions.Xunit" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.20" />

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoBogus" Version="2.13.1" />
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
     <PackageReference Include="GSoft.Extensions.Xunit" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.20" />

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/Workleap.DomainEventPropagation.Subscription.PullDelivery.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/Workleap.DomainEventPropagation.Subscription.PullDelivery.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.7.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Core" Version="1.36.0" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.22.0-beta.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />


### PR DESCRIPTION
`Azure.Identity` at its previous version was flagged as vulnerable when the solution was built.

It was upgraded to its latest version, which is also non-vulnerable.