### PR TITLE
[IDP-1031] Remove parameterless constructor reqs on interfaces

### DIFF
--- a/src/Shared/DomainEventWrapper.cs
+++ b/src/Shared/DomainEventWrapper.cs
@@ -69,7 +69,7 @@ internal sealed class DomainEventWrapper
     }
 
     public static DomainEventWrapper Wrap<T>(T domainEvent)
-        where T : IDomainEvent, new()
+        where T : IDomainEvent
     {
         var domainEventName = DomainEventNameCache.GetName<T>();
         var domainEventSchema = DomainEventSchemaCache.GetEventSchema<T>();

--- a/src/Shared/DomainEventWrapperCollection.cs
+++ b/src/Shared/DomainEventWrapperCollection.cs
@@ -20,7 +20,7 @@ internal sealed class DomainEventWrapperCollection : IReadOnlyCollection<DomainE
     public EventSchema DomainSchema { get; }
 
     public static DomainEventWrapperCollection Create<T>(IEnumerable<T> domainEvents)
-        where T : IDomainEvent, new()
+        where T : IDomainEvent
     {
         var domainEventWrappers = domainEvents.Select(DomainEventWrapper.Wrap).ToArray();
         

--- a/src/Workleap.DomainEventPropagation.Abstractions/DomainEventNameCache.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/DomainEventNameCache.cs
@@ -9,7 +9,7 @@ internal static class DomainEventNameCache
     private static readonly ConcurrentDictionary<Type, string> DomainEventNameTypeMappings = new ConcurrentDictionary<Type, string>();
 
     public static string GetName<T>()
-        where T : IDomainEvent, new()
+        where T : IDomainEvent
     {
         return GetName(typeof(T));
     }

--- a/src/Workleap.DomainEventPropagation.Abstractions/DomainEventSchemaCache.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/DomainEventSchemaCache.cs
@@ -9,7 +9,7 @@ internal static class DomainEventSchemaCache
     private static readonly ConcurrentDictionary<Type, EventSchema> DomainEventSchemaTypeMappings = new();
 
     public static EventSchema GetEventSchema<T>()
-        where T : IDomainEvent, new()
+        where T : IDomainEvent
     {
         return GetEventSchema(typeof(T));
     }

--- a/src/Workleap.DomainEventPropagation.Abstractions/IEventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/IEventPropagationClient.cs
@@ -3,8 +3,8 @@ namespace Workleap.DomainEventPropagation;
 public interface IEventPropagationClient
 {
     Task PublishDomainEventAsync<T>(T domainEvent, CancellationToken cancellationToken)
-        where T : IDomainEvent, new();
+        where T : IDomainEvent;
 
     Task PublishDomainEventsAsync<T>(IEnumerable<T> domainEvents, CancellationToken cancellationToken)
-        where T : IDomainEvent, new();
+        where T : IDomainEvent;
 }

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
@@ -40,11 +40,11 @@ internal sealed class EventPropagationClient : IEventPropagationClient
     }
 
     public Task PublishDomainEventAsync<T>(T domainEvent, CancellationToken cancellationToken)
-        where T : IDomainEvent, new()
+        where T : IDomainEvent
         => this.PublishDomainEventsAsync(new[] { domainEvent }, cancellationToken);
 
     public async Task PublishDomainEventsAsync<T>(IEnumerable<T> domainEvents, CancellationToken cancellationToken)
-        where T : IDomainEvent, new()
+        where T : IDomainEvent
     {
         if (domainEvents == null)
         {


### PR DESCRIPTION
## Description of changes
There was a breaking change introduced that required parameterless constructors on some of our interfaces. This caused issues with how DomainEvent could previously be defined as a records.

## Breaking changes
Given that the changes were not released yet, there should be no breaking changes

## Additional checks
Validated with a dev package version that bug was fixed

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
