### PR TITLE
[SGCORE-422] Add support for CloudEvents in Push model

### DIFF
--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Channels;
+using System.Threading.Channels;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
@@ -8,6 +8,7 @@ using Workleap.DomainEventPropagation.Tests;
 
 namespace Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests;
 
+[Collection("Sequential")]
 public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
 {
     private const string TopicName = "Topic1";

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
@@ -10,12 +10,12 @@ namespace Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests;
 
 public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
 {
-    private const int EmulatorPort = 6504;
+    private const int EmulatorPort = 6500;
     private const string TopicName = "Topic1";
     private const string SubscriberName = "subscriber1";
     private const int EventId = 1;
     
-    [Fact(Skip = "testing to see if a race condition is breaking CI")]
+    [Fact]
     public async Task TestPublishAndReceiveEvent()
     {
         // Add a timeout for the test to not block indefinitely
@@ -125,12 +125,9 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
         {
             return new ContainerBuilder()
                 .WithImage("workleap/eventgridemulator:0.2.0") // TODO Renovate this?
-                .WithExposedPort(EmulatorPort)
-                .WithEnvironment("ASPNETCORE_URLS", $"http://+:{EmulatorPort}")
                 .WithPortBinding(EmulatorPort, assignRandomHostPort: true)
                 .WithBindMount(configurationPath, "/app/appsettings.json", AccessMode.ReadOnly)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))
-                .WithName("eventgrid-emulator-pull-delivery")
                 .Build();
         }
 

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
@@ -10,7 +10,7 @@ namespace Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests;
 
 public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
 {
-    private const int EmulatorPort = 6500;
+    private const int EmulatorPort = 6504;
     private const string TopicName = "Topic1";
     private const string SubscriberName = "subscriber1";
     private const int EventId = 1;
@@ -130,6 +130,7 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
                 .WithPortBinding(EmulatorPort, assignRandomHostPort: true)
                 .WithBindMount(configurationPath, "/app/appsettings.json", AccessMode.ReadOnly)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))
+                .WithName("eventgrid-emulator-pull-delivery")
                 .Build();
         }
 

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
@@ -15,7 +15,7 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
     private const string SubscriberName = "subscriber1";
     private const int EventId = 1;
     
-    [Fact]
+    [Fact(Skip = "testing to see if a race condition is breaking CI")]
     public async Task TestPublishAndReceiveEvent()
     {
         // Add a timeout for the test to not block indefinitely

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
@@ -8,9 +8,9 @@ using Workleap.DomainEventPropagation.Tests;
 
 namespace Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests;
 
-[Collection("Sequential")]
 public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
 {
+    private const int EmulatorPort = 6500;
     private const string TopicName = "Topic1";
     private const string SubscriberName = "subscriber1";
     private const int EventId = 1;
@@ -90,7 +90,7 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
 
     private sealed class EventGridEmulatorContext(IContainer container) : IAsyncDisposable
     {
-        public string Url { get; } = $"http://localhost:{container.GetMappedPublicPort(6500)}/";
+        public string Url { get; } = $"http://localhost:{container.GetMappedPublicPort(EmulatorPort)}/";
 
         public static async Task<EventGridEmulatorContext> StartAsync(ITestOutputHelper testOutputHelper)
         {
@@ -125,9 +125,11 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
         {
             return new ContainerBuilder()
                 .WithImage("workleap/eventgridemulator:0.2.0") // TODO Renovate this?
-                .WithPortBinding(6500, assignRandomHostPort: true)
+                .WithExposedPort(EmulatorPort)
+                .WithEnvironment("ASPNETCORE_URLS", $"http://+:{EmulatorPort}")
+                .WithPortBinding(EmulatorPort, assignRandomHostPort: true)
                 .WithBindMount(configurationPath, "/app/appsettings.json", AccessMode.ReadOnly)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(6500))
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))
                 .Build();
         }
 

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiUnitTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiUnitTests.cs
@@ -107,22 +107,17 @@ public class EventsApiUnitTests
     }
 
     [Fact]
-    public async Task GivenEventsApiHandleEvent_WhenEventIsNeitherEventGridEventOrCloudEvent_ThenReturns500Result()
+    public async Task GivenEventsApiHandleEvent_WhenEventIsNeitherEventGridEventOrCloudEvent_ThenThrows()
     {
         // Given
         var httpRequest = await CreateHttpRequest(new { Unknown = "Event" });
 
         // When
-        var actualResult = await EventsApi.HandleEvents(httpRequest, this._eventGridRequestHandler, CancellationToken.None);
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(() => EventsApi.HandleEvents(httpRequest, this._eventGridRequestHandler, CancellationToken.None));
 
         // Then
-        var (data, statusCode) = await actualResult.GetResponseAsync<object>();
-
-        Assert.Equal(HttpStatusCode.InternalServerError, statusCode);
-        Assert.NotNull(data);
-
-        var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(data.ToString()!);
-        Assert.Contains("Unknown payload", problemDetails!.Detail);
+        Assert.NotNull(ex);
+        Assert.Contains("Unknown payload", ex.Message);
     }
 
     private static EventGridEvent[] GenerateEventGridEvents()

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiUnitTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiUnitTests.cs
@@ -105,6 +105,22 @@ public class EventsApiUnitTests
         Assert.Null(data);
     }
 
+    [Fact]
+    public async Task GivenEventsApiHandleEvent_WhenEventIsNeitherEventGridEventOrCloudEvent_ThenReturns500Result()
+    {
+        // Given
+        var httpRequest = await CreateHttpRequest(new { Unknown = "Event" });
+
+        // When
+        var actualResult = await EventsApi.HandleEvents(httpRequest, this._eventGridRequestHandler, CancellationToken.None);
+
+        // Then
+        var (data, statusCode) = await actualResult.GetResponseAsync<object>();
+
+        Assert.Equal(HttpStatusCode.InternalServerError, statusCode);
+        Assert.Null(data);
+    }
+
     private static EventGridEvent[] GenerateEventGridEvents()
     {
         var eventGridEvent = new EventGridEvent("subject", "Workleap.DomainEventPropagation.Dummy.Type", "1.0", new BinaryData(new { id = Guid.NewGuid() }))

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiUnitTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiUnitTests.cs
@@ -5,6 +5,7 @@ using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventGrid.SystemEvents;
 using FakeItEasy;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Workleap.DomainEventPropagation.Subscription.Tests.Apis;
 
@@ -118,7 +119,10 @@ public class EventsApiUnitTests
         var (data, statusCode) = await actualResult.GetResponseAsync<object>();
 
         Assert.Equal(HttpStatusCode.InternalServerError, statusCode);
-        Assert.Null(data);
+        Assert.NotNull(data);
+
+        var problemDetails = JsonSerializer.Deserialize<ProblemDetails>(data.ToString()!);
+        Assert.Contains("Unknown payload", problemDetails!.Detail);
     }
 
     private static EventGridEvent[] GenerateEventGridEvents()

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiUnitTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Apis/EventsApiUnitTests.cs
@@ -1,7 +1,10 @@
 using System.Net;
+using System.Text.Json;
+using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventGrid.SystemEvents;
 using FakeItEasy;
+using Microsoft.AspNetCore.Http;
 
 namespace Workleap.DomainEventPropagation.Subscription.Tests.Apis;
 
@@ -15,7 +18,7 @@ public class EventsApiUnitTests
     }
 
     [Fact]
-    public async Task GivenEventsApiHandleEvent_WhenResultRequestTypeIsSubscription_ThenReturnsOkResultWithValidationCode()
+    public async Task GivenEventsApiHandleEventGridEvent_WhenResultRequestTypeIsSubscription_ThenReturnsOkResultWithValidationCode()
     {
         // Given
         var subscriptionValidationResponse = new SubscriptionValidationResponse
@@ -23,12 +26,13 @@ public class EventsApiUnitTests
             ValidationResponse = "abcdef",
         };
 
+        var httpRequest = await CreateHttpRequest(GenerateEventGridEvents());
         var eventGridRequestResult = new EventGridRequestResult(EventGridRequestType.Subscription, subscriptionValidationResponse);
 
         A.CallTo(() => this._eventGridRequestHandler.HandleRequestAsync(A<EventGridEvent[]>._, A<CancellationToken>._)).Returns(Task.FromResult(eventGridRequestResult));
 
         // When
-        var actualResult = await EventsApi.HandleEventGridEvents(Array.Empty<EventGridEvent>(), this._eventGridRequestHandler, CancellationToken.None);
+        var actualResult = await EventsApi.HandleEvents(httpRequest, this._eventGridRequestHandler, CancellationToken.None);
 
         // Then
         var (data, statusCode) = await actualResult.GetResponseAsync<SubscriptionValidationResponse>();
@@ -39,20 +43,107 @@ public class EventsApiUnitTests
     }
 
     [Fact]
-    public async Task GivenEventsApiHandleEvent_WhenResultRequestTypeIsNotSubscription_ThenReturnsOkResult()
+    public async Task GivenEventsApiHandleCloudEvent_WhenResultRequestTypeIsSubscription_ThenReturnsOkResultWithValidationCode()
+    {
+        // Given
+        var subscriptionValidationResponse = new SubscriptionValidationResponse
+        {
+            ValidationResponse = "abcdef",
+        };
+
+        var httpRequest = await CreateHttpRequest(GenerateCloudEvents());
+        var eventGridRequestResult = new EventGridRequestResult(EventGridRequestType.Subscription, subscriptionValidationResponse);
+
+        A.CallTo(() => this._eventGridRequestHandler.HandleRequestAsync(A<CloudEvent[]>._, A<CancellationToken>._)).Returns(Task.FromResult(eventGridRequestResult));
+
+        // When
+        var actualResult = await EventsApi.HandleEvents(httpRequest, this._eventGridRequestHandler, CancellationToken.None);
+
+        // Then
+        var (data, statusCode) = await actualResult.GetResponseAsync<SubscriptionValidationResponse>();
+
+        Assert.Equal(HttpStatusCode.OK, statusCode);
+        Assert.NotNull(data);
+        Assert.Equal(subscriptionValidationResponse.ValidationResponse, data.ValidationResponse);
+    }
+
+    [Fact]
+    public async Task GivenEventsApiHandleEventGridEvent_WhenResultRequestTypeIsNotSubscription_ThenReturnsOkResult()
     {
         // Given
         var eventGridRequestResult = new EventGridRequestResult(EventGridRequestType.Event);
 
+        var httpRequest = await CreateHttpRequest(GenerateEventGridEvents());
         A.CallTo(() => this._eventGridRequestHandler.HandleRequestAsync(A<EventGridEvent[]>._, A<CancellationToken>._)).Returns(Task.FromResult(eventGridRequestResult));
 
         // When
-        var actualResult = await EventsApi.HandleEventGridEvents(Array.Empty<EventGridEvent>(), this._eventGridRequestHandler, CancellationToken.None);
+        var actualResult = await EventsApi.HandleEvents(httpRequest, this._eventGridRequestHandler, CancellationToken.None);
 
         // Then
         var (data, statusCode) = await actualResult.GetResponseAsync<object>();
 
         Assert.Equal(HttpStatusCode.OK, statusCode);
         Assert.Null(data);
+    }
+
+    [Fact]
+    public async Task GivenEventsApiHandleCloudEvent_WhenResultRequestTypeIsNotSubscription_ThenReturnsOkResult()
+    {
+        // Given
+        var eventGridRequestResult = new EventGridRequestResult(EventGridRequestType.Event);
+
+        var httpRequest = await CreateHttpRequest(GenerateCloudEvents());
+        A.CallTo(() => this._eventGridRequestHandler.HandleRequestAsync(A<CloudEvent[]>._, A<CancellationToken>._)).Returns(Task.FromResult(eventGridRequestResult));
+
+        // When
+        var actualResult = await EventsApi.HandleEvents(httpRequest, this._eventGridRequestHandler, CancellationToken.None);
+
+        // Then
+        var (data, statusCode) = await actualResult.GetResponseAsync<object>();
+
+        Assert.Equal(HttpStatusCode.OK, statusCode);
+        Assert.Null(data);
+    }
+
+    private static EventGridEvent[] GenerateEventGridEvents()
+    {
+        var eventGridEvent = new EventGridEvent("subject", "Workleap.DomainEventPropagation.Dummy.Type", "1.0", new BinaryData(new { id = Guid.NewGuid() }))
+        {
+            Topic = "topic",
+        };
+
+        return [eventGridEvent];
+    }
+
+    private static CloudEvent[] GenerateCloudEvents()
+    {
+        var cloudEvent = new CloudEvent("source", "Workleap.DomainEventPropagation.Dummy.Type", new { id = Guid.NewGuid() })
+        {
+            Subject = "subject",
+        };
+
+        return [cloudEvent];
+    }
+
+    private static async Task<HttpRequest> CreateHttpRequest(object body)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            Request =
+            {
+                Method = "POST",
+                Scheme = "http",
+                Host = new HostString("localhost"),
+                ContentType = "application/json",
+            },
+        };
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        await writer.WriteAsync(JsonSerializer.Serialize(body));
+        await writer.FlushAsync();
+        stream.Position = 0;
+        httpContext.Request.Body = stream;
+
+        return httpContext.Request;
     }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/EventGridRequestHandlerTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/EventGridRequestHandlerTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventGrid.SystemEvents;
 using FakeItEasy;
@@ -24,6 +24,33 @@ public class EventGridRequestHandlerTests
             subscriptionEventGridWebhookHandler);
 
         var request = GetEventGridSubscriptionRequest(validationCode);
+
+        var result = await eventGridRequestHandler.HandleRequestAsync(request, CancellationToken.None);
+
+        // Then
+        Assert.NotNull(result);
+        Assert.NotNull(result.ValidationResponse);
+        Assert.Equal(validationCode, result.ValidationResponse.ValidationResponse);
+        Assert.Equal(EventGridRequestType.Subscription, result.RequestType);
+    }
+
+    [Fact]
+    public async Task GivenSubscriptionCloudEventRequest_WhenRequestContentValid_ThenAcceptResponseIsGenerated()
+    {
+        // Given
+        var validationCode = Guid.NewGuid().ToString();
+        var domainEventGridWebhookHandler = A.Fake<IDomainEventGridWebhookHandler>();
+        var subscriptionEventGridWebhookHandler = A.Fake<ISubscriptionEventGridWebhookHandler>();
+
+        A.CallTo(() => subscriptionEventGridWebhookHandler.HandleEventGridSubscriptionEvent(A<SubscriptionValidationEventData>._))
+            .Returns(new SubscriptionValidationResponse { ValidationResponse = validationCode });
+
+        // When
+        var eventGridRequestHandler = new EventGridRequestHandler(
+            domainEventGridWebhookHandler,
+            subscriptionEventGridWebhookHandler);
+
+        var request = GetCloudEventSubscriptionRequest(validationCode);
 
         var result = await eventGridRequestHandler.HandleRequestAsync(request, CancellationToken.None);
 
@@ -62,6 +89,33 @@ public class EventGridRequestHandlerTests
     }
 
     [Fact]
+    public async Task GivenSubscriptionCloudEventRequest_WhenExceptionIsThrown_ThenExceptionIsTracked()
+    {
+        // Given
+        var validationCode = Guid.NewGuid().ToString();
+        var domainEventGridWebhookHandler = A.Fake<IDomainEventGridWebhookHandler>();
+        var subscriptionEventGridWebhookHandler = A.Fake<ISubscriptionEventGridWebhookHandler>();
+
+        A.CallTo(() => subscriptionEventGridWebhookHandler.HandleEventGridSubscriptionEvent(A<SubscriptionValidationEventData>._))
+            .Throws(new Exception("An exception was thrown"));
+
+        // When
+        var eventGridRequestHandler = new EventGridRequestHandler(
+            domainEventGridWebhookHandler,
+            subscriptionEventGridWebhookHandler);
+
+        var request = GetCloudEventSubscriptionRequest(validationCode);
+
+        var exception = await Assert.ThrowsAsync<Exception>(() =>
+        {
+            return eventGridRequestHandler.HandleRequestAsync(request, CancellationToken.None);
+        });
+
+        // Then
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
     public async Task GivenSubscriptionEventGridRequest_WhenRequestContentValidAndContainsTelemetryCorrelationId_ThenRequestTelemetryParentIdIsNotSet()
     {
         // Given
@@ -78,6 +132,32 @@ public class EventGridRequestHandlerTests
             subscriptionEventGridWebhookHandler);
 
         var request = GetEventGridSubscriptionRequest(validationCode);
+        var result = await eventGridRequestHandler.HandleRequestAsync(request, CancellationToken.None);
+
+        // Then
+        Assert.NotNull(result);
+        Assert.NotNull(result.ValidationResponse);
+        Assert.Equal(validationCode, result.ValidationResponse.ValidationResponse);
+        Assert.Equal(EventGridRequestType.Subscription, result.RequestType);
+    }
+
+    [Fact]
+    public async Task GivenSubscriptionCloudEventRequest_WhenRequestContentValidAndContainsTelemetryCorrelationId_ThenRequestTelemetryParentIdIsNotSet()
+    {
+        // Given
+        var validationCode = Guid.NewGuid().ToString();
+        var domainEventGridWebhookHandler = A.Fake<IDomainEventGridWebhookHandler>();
+        var subscriptionEventGridWebhookHandler = A.Fake<ISubscriptionEventGridWebhookHandler>();
+
+        A.CallTo(() => subscriptionEventGridWebhookHandler.HandleEventGridSubscriptionEvent(A<SubscriptionValidationEventData>._))
+            .Returns(new SubscriptionValidationResponse { ValidationResponse = validationCode });
+
+        // When
+        var eventGridRequestHandler = new EventGridRequestHandler(
+            domainEventGridWebhookHandler,
+            subscriptionEventGridWebhookHandler);
+
+        var request = GetCloudEventSubscriptionRequest(validationCode);
         var result = await eventGridRequestHandler.HandleRequestAsync(request, CancellationToken.None);
 
         // Then
@@ -111,6 +191,29 @@ public class EventGridRequestHandlerTests
     }
 
     [Fact]
+    public async Task GivenDomainEventCloudEventRequest_WhenRequestContentValidAndContainsTelemetryCorrelationId_ThenRequestTelemetryParentIdIsSet()
+    {
+        // Given
+        var domainEventGridWebhookHandler = A.Fake<IDomainEventGridWebhookHandler>();
+        var subscriptionEventGridWebhookHandler = A.Fake<ISubscriptionEventGridWebhookHandler>();
+
+        A.CallTo(() => domainEventGridWebhookHandler.HandleEventGridWebhookEventAsync(A<EventGridEvent>._, CancellationToken.None))
+            .Returns(Task.CompletedTask);
+
+        // When
+        var eventGridRequestHandler = new EventGridRequestHandler(
+            domainEventGridWebhookHandler,
+            subscriptionEventGridWebhookHandler);
+
+        var request = GetCloudEventDomainEventRequest();
+        var result = await eventGridRequestHandler.HandleRequestAsync(request, CancellationToken.None);
+
+        // Then
+        Assert.NotNull(result);
+        Assert.Equal(EventGridRequestType.Event, result.RequestType);
+    }
+
+    [Fact]
     public async Task GivenDomainEventEventGridRequest_WhenRequestThrowsExceptionAndContainsTelemetryCorrelationId_ThenRequestTelemetryIsTracked()
     {
         // Given
@@ -125,6 +228,26 @@ public class EventGridRequestHandlerTests
             subscriptionEventGridWebhookHandler);
 
         var request = GetEventGridDomainEventRequest();
+
+        // Then
+        await Assert.ThrowsAsync<Exception>(() => eventGridRequestHandler.HandleRequestAsync(request, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GivenDomainEventCloudEventRequest_WhenRequestThrowsExceptionAndContainsTelemetryCorrelationId_ThenRequestTelemetryIsTracked()
+    {
+        // Given
+        var domainEventGridWebhookHandler = A.Fake<IDomainEventGridWebhookHandler>();
+        var subscriptionEventGridWebhookHandler = A.Fake<ISubscriptionEventGridWebhookHandler>();
+        A.CallTo(() => domainEventGridWebhookHandler.HandleEventGridWebhookEventAsync(A<CloudEvent>._, CancellationToken.None))
+            .Throws(new Exception("An exception was thrown"));
+
+        // When
+        var eventGridRequestHandler = new EventGridRequestHandler(
+            domainEventGridWebhookHandler,
+            subscriptionEventGridWebhookHandler);
+
+        var request = GetCloudEventDomainEventRequest();
 
         // Then
         await Assert.ThrowsAsync<Exception>(() => eventGridRequestHandler.HandleRequestAsync(request, CancellationToken.None));
@@ -151,55 +274,75 @@ public class EventGridRequestHandlerTests
             .MustHaveHappenedOnceExactly();
     }
 
+    [Fact]
+    public async Task GivenDomainEventCloudEventRequest_WhenRequestTelemetryNull_ThenOperationSucceeds()
+    {
+        // Given
+        var domainEventGridWebhookHandler = A.Fake<IDomainEventGridWebhookHandler>();
+        var subscriptionEventGridWebhookHandler = A.Fake<ISubscriptionEventGridWebhookHandler>();
+
+        // When
+        var eventGridRequestHandler = new EventGridRequestHandler(
+            domainEventGridWebhookHandler,
+            subscriptionEventGridWebhookHandler);
+
+        var request = GetCloudEventDomainEventRequest();
+
+        await eventGridRequestHandler.HandleRequestAsync(request, CancellationToken.None);
+
+        // Then
+        A.CallTo(() => domainEventGridWebhookHandler.HandleEventGridWebhookEventAsync(A<CloudEvent>._, CancellationToken.None))
+            .MustHaveHappenedOnceExactly();
+    }
+
     private static EventGridEvent[] GetEventGridSubscriptionRequest(string validationCode)
     {
-        // TODO Replace string manipulation with JSON serialization
-        var subscriptionRequest = @"[{
-                'topic': '/subscriptions/topic-egt-',
-                'subject': '',
-                'eventType': 'Microsoft.EventGrid.SubscriptionValidationEvent',
-                'eventTime': '2017-08-16T01:57:26.005121Z',
-                'id': '602a88ef-0001-00e6-1233-1646070610ea',
-                'data': {eventData},
-                'metadataVersion': '1',
-                'dataVersion': '1'
-            }]";
+        var eventGridEvent = new EventGridEvent(string.Empty, "Microsoft.EventGrid.SubscriptionValidationEvent", "1", new LocalSubscriptionValidationEventData(validationCode, "https://validationurl.io"))
+        {
+            Id = Guid.Parse("602a88ef-0001-00e6-1233-1646070610ea").ToString(),
+            EventTime = DateTimeOffset.Parse("2017-08-16T01:57:26.005121Z"),
+            Topic = "/subscriptions/topic-egt-",
+        };
 
-        var eventData = @"{
-                  'validationCode': '{validationCode}',
-                  'validationUrl': 'https://validationurl.io'
-            }";
+        return [eventGridEvent];
+    }
 
-        eventData = eventData.Replace("'", "\"");
+    private static CloudEvent[] GetCloudEventSubscriptionRequest(string validationCode)
+    {
+        var cloudEvent = new CloudEvent("/subscriptions-topic-egt-", "Microsoft.EventGrid.SubscriptionValidationEvent", new LocalSubscriptionValidationEventData(validationCode, "https://validationurl.io"))
+        {
+            Id = Guid.Parse("602a88ef-0001-00e6-1233-1646070610ea").ToString(),
+            Time = DateTimeOffset.Parse("2017-08-16T01:57:26.005121Z"),
+        };
 
-        subscriptionRequest = subscriptionRequest.Replace("{eventData}", eventData).Replace("'", "\"").Replace("{validationCode}", validationCode);
-
-        return JsonSerializer.Deserialize<EventGridEvent[]>(subscriptionRequest)!;
+        return [cloudEvent];
     }
 
     private static EventGridEvent[] GetEventGridDomainEventRequest()
     {
-        // TODO Replace string manipulation with JSON serialization
-        var domainEventRequest = @"[{
-                'topic': '/subscriptions/topic-egt-',
-                'subject': 'Test',
-                'eventType': 'Workleap.Organization.DomainEvents.ExampleDomainEvent',
-                'eventTime': '2017-08-16T01:57:26.005121Z',
-                'id': '602a88ef-0001-00e6-1233-1646070610ea',
-                'data': {eventData},
-                'metadataVersion': '1',
-                'dataVersion': '1'
-             }]";
+        var eventGridEvent = new EventGridEvent("Test", "Workleap.Organization.DomainEvents.ExampleDomainEvent", "1", new ExampleDomainEvent(DateTimeOffset.Parse("2017-08-16T01:57:26.005121Z"), Guid.Parse("b59ff87c-9bfb-46b7-9092-04735202d2f6")))
+        {
+            Id = Guid.Parse("602a88ef-0001-00e6-1233-1646070610ea").ToString(),
+            EventTime = DateTimeOffset.Parse("2017-08-16T01:57:26.005121Z"),
+            Topic = "/subscriptions/topic-egt-",
+        };
 
-        var eventData = @"{
-                  'eventDate': '2017-08-16T01:57:26.005121Z',
-                  'eventId': 'b59ff87c-9bfb-46b7-9092-04735202d2f6'
-                }";
+        return [eventGridEvent];
+    }
 
-        eventData = eventData.Replace("'", "\"");
+    private static CloudEvent[] GetCloudEventDomainEventRequest()
+    {
+        var cloudEvent = new CloudEvent("/subscriptions/topic-egt-", "Workleap.Organization.DomainEvents.ExampleDomainEvent", new ExampleDomainEvent(DateTimeOffset.Parse("2017-08-16T01:57:26.005121Z"), Guid.Parse("b59ff87c-9bfb-46b7-9092-04735202d2f6")))
+        {
+            Id = Guid.Parse("602a88ef-0001-00e6-1233-1646070610ea").ToString(),
+            Subject = "Test",
+            Time = DateTimeOffset.Parse("2017-08-16T01:57:26.005121Z"),
+        };
 
-        domainEventRequest = domainEventRequest.Replace("{eventData}", eventData).Replace("'", "\"");
-
-        return JsonSerializer.Deserialize<EventGridEvent[]>(domainEventRequest)!;
+        return [cloudEvent];
     }
 }
+
+internal record LocalSubscriptionValidationEventData(string ValidationCode, string ValidationUrl);
+
+internal record ExampleDomainEvent(DateTimeOffset EventDate, Guid EventId);

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/EventGridRequestHandlerTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/EventGridRequestHandlerTests.cs
@@ -343,6 +343,6 @@ public class EventGridRequestHandlerTests
     }
 }
 
-internal record LocalSubscriptionValidationEventData(string ValidationCode, string ValidationUrl);
+internal sealed record LocalSubscriptionValidationEventData(string ValidationCode, string ValidationUrl);
 
-internal record ExampleDomainEvent(DateTimeOffset EventDate, Guid EventId);
+internal sealed record ExampleDomainEvent(DateTimeOffset EventDate, Guid EventId);

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
@@ -11,7 +11,7 @@ namespace Workleap.DomainEventPropagation.Subscription.Tests;
 
 public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
 {
-    private const int EmulatorPort = 6505;
+    private const int EmulatorPort = 6500;
     private const string TopicName = "Topic1";
     private const string SubscriberEndpoint = "/my-webhook";
     private const string LocalUrl = "http://host.testcontainers.internal:5000";
@@ -118,6 +118,7 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
         {
             var configurationPath = await WriteConfigurationFile(testOutputHelper);
 
+            await TestcontainersSettings.ExposeHostPortsAsync(5000);
             var container = BuildContainer(configurationPath);
             
             try
@@ -147,13 +148,9 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
         {
             return new ContainerBuilder()
                 .WithImage("workleap/eventgridemulator:0.2.0") // TODO Renovate this?
-                .WithExposedPort(EmulatorPort)
-                .WithEnvironment("ASPNETCORE_URLS", $"http://+:{EmulatorPort}")
                 .WithPortBinding(EmulatorPort, assignRandomHostPort: true)
                 .WithBindMount(configurationPath, "/app/appsettings.json", AccessMode.ReadOnly)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))
-                .WithName("eventgrid-emulator-push-delivery")
-                .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())
                 .Build();
         }
 

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
@@ -152,6 +152,7 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
                 .WithPortBinding(EmulatorPort, assignRandomHostPort: true)
                 .WithBindMount(configurationPath, "/app/appsettings.json", AccessMode.ReadOnly)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))
+                .WithName("eventgrid-emulator-push-delivery")
                 .Build();
         }
 

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
@@ -153,6 +153,7 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
                 .WithBindMount(configurationPath, "/app/appsettings.json", AccessMode.ReadOnly)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))
                 .WithName("eventgrid-emulator-push-delivery")
+                .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())
                 .Build();
         }
 

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
@@ -14,7 +14,7 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
     private const int EmulatorPort = 6505;
     private const string TopicName = "Topic1";
     private const string SubscriberEndpoint = "/my-webhook";
-    private const string LocalUrl = "http://host.docker.internal:5000";
+    private const string LocalUrl = "http://host.testcontainers.internal:5000";
     private const int EventGridId = 1;
     private const int CloudEventId = 2;
     
@@ -117,7 +117,8 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
         public static async Task<EventGridEmulatorContext> StartAsync(ITestOutputHelper testOutputHelper)
         {
             var configurationPath = await WriteConfigurationFile(testOutputHelper);
-            
+
+            await TestcontainersSettings.ExposeHostPortsAsync(5000);
             var container = BuildContainer(configurationPath);
             
             try
@@ -154,7 +155,6 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))
                 .WithName("eventgrid-emulator-push-delivery")
                 .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())
-                .WithExtraHost("host.docker.internal", "host-gateway")
                 .Build();
         }
 

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
@@ -154,6 +154,7 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))
                 .WithName("eventgrid-emulator-push-delivery")
                 .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())
+                .WithExtraHost("host.docker.internal", "host-gateway")
                 .Build();
         }
 

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
@@ -118,7 +118,6 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
         {
             var configurationPath = await WriteConfigurationFile(testOutputHelper);
 
-            await TestcontainersSettings.ExposeHostPortsAsync(5000);
             var container = BuildContainer(configurationPath);
             
             try

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
@@ -9,6 +9,7 @@ using Workleap.DomainEventPropagation.Tests;
 
 namespace Workleap.DomainEventPropagation.Subscription.Tests;
 
+[Collection("Sequential")]
 public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
 {
     private const string TopicName = "Topic1";

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
@@ -1,0 +1,189 @@
+using System.Threading.Channels;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Workleap.DomainEventPropagation.Tests;
+
+namespace Workleap.DomainEventPropagation.Subscription.Tests;
+
+public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
+{
+    private const string TopicName = "Topic1";
+    private const string SubscriberEndpoint = "/my-webhook";
+    private const string LocalUrl = "http://host.docker.internal:5000";
+    private const int EventGridId = 1;
+    private const int CloudEventId = 2;
+    
+    [Fact]
+    public async Task TestPublishAndReceiveEvent()
+    {
+        // Add a timeout for the test to not block indefinitely
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+
+        // Enable activity tracking
+        using var activityTracker = new InMemoryActivityTracker();
+        
+        // Start Event Grid Emulator
+        await using var eventGridEmulator = await EventGridEmulatorContext.StartAsync(testOutputHelper);
+        
+        // Configure the publisher and the subscriptions, and start the service
+        var host = this.BuildHost(eventGridEmulator.Url);
+        var runTask = host.RunAsync(cts.Token); // The method returns when the services are running
+
+        // Send an EventGrid event
+        var client = host.Services.GetRequiredService<IEventPropagationClient>();
+        await client.PublishDomainEventsAsync([new TestEventGridEvent { Id = EventGridId }], cts.Token);
+        activityTracker.AssertPublishSuccessful("EventGridEvents create com.workleap.sample.testEventGridEvent");
+
+        // Send a CloudEvent
+        await client.PublishDomainEventsAsync([new TestCloudEvent { Id = CloudEventId }], cts.Token);
+        activityTracker.AssertPublishSuccessful("CloudEvents create com.workleap.sample.testCloudEvent");
+
+        // Read the events. The background service should call TestDomainEventHandler, so the channel should have 1 item each
+        var eventGridChannel = host.Services.GetRequiredService<Channel<TestEventGridEvent>>();
+        var processedEvent = await eventGridChannel.Reader.ReadAsync(cts.Token);
+        Assert.Equal(EventGridId, processedEvent.Id);
+        activityTracker.AssertSubscribeSuccessful("EventGridEvents process com.workleap.sample.testEventGridEvent");
+
+        var cloudChannel = host.Services.GetRequiredService<Channel<TestCloudEvent>>();
+        var processedCloudEvent = await cloudChannel.Reader.ReadAsync(cts.Token);
+        Assert.Equal(CloudEventId, processedCloudEvent.Id);
+        activityTracker.AssertSubscribeSuccessful("CloudEvents process com.workleap.sample.testCloudEvent");
+
+        // Terminate the service
+        host.Services.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+        await runTask;
+    }
+
+    private IHost BuildHost(string eventGridUrl)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.ConfigureServices(services =>
+        {
+            services.AddSingleton(Channel.CreateUnbounded<TestEventGridEvent>());
+            services.AddSingleton(Channel.CreateUnbounded<TestCloudEvent>());
+            services.AddEventPropagationPublisher(options =>
+            {
+                options.TopicEndpoint = $"{eventGridUrl}{TopicName}/api/events";
+                options.TopicName = TopicName;
+                options.TopicAccessKey = "noop";
+                options.TopicType = TopicType.Custom;
+            });
+            services.AddEventPropagationSubscriber()
+                .AddDomainEventHandler<TestEventGridEvent, TestDomainEventHandler>()
+                .AddDomainEventHandler<TestCloudEvent, TestDomainEventHandler>();
+        });
+
+        var webApp = builder.Build();
+
+        webApp.MapEventPropagationEndpoint(SubscriberEndpoint);
+
+        return webApp;
+    }
+
+    [DomainEvent("com.workleap.sample.testEventGridEvent")]
+    private sealed record TestEventGridEvent : IDomainEvent
+    {
+        public int Id { get; set; }
+    }
+
+    [DomainEvent("com.workleap.sample.testCloudEvent", EventSchema.CloudEvent)]
+    private sealed record TestCloudEvent : IDomainEvent
+    {
+        public int Id { get; set; }
+    }
+
+    private sealed class TestDomainEventHandler(Channel<TestEventGridEvent> eventGridChannel, Channel<TestCloudEvent> cloudChannel) : IDomainEventHandler<TestEventGridEvent>, IDomainEventHandler<TestCloudEvent>
+    {
+        public async Task HandleDomainEventAsync(TestEventGridEvent domainEvent, CancellationToken cancellationToken)
+        {
+            await eventGridChannel.Writer.WriteAsync(domainEvent, cancellationToken);
+        }
+
+        public async Task HandleDomainEventAsync(TestCloudEvent domainEvent, CancellationToken cancellationToken)
+        {
+            await cloudChannel.Writer.WriteAsync(domainEvent, cancellationToken);
+        }
+    }
+
+    private sealed class EventGridEmulatorContext(IContainer container) : IAsyncDisposable
+    {
+        public string Url { get; } = $"http://localhost:{container.GetMappedPublicPort(6500)}/";
+
+        public static async Task<EventGridEmulatorContext> StartAsync(ITestOutputHelper testOutputHelper)
+        {
+            var configurationPath = await WriteConfigurationFile(testOutputHelper);
+            
+            var container = BuildContainer(configurationPath);
+            
+            try
+            {
+                await container.StartAsync();
+            }
+            catch
+            {
+                try
+                {
+                    var logs = await container.GetLogsAsync();
+                    testOutputHelper.WriteLine(logs.Stdout);
+                    testOutputHelper.WriteLine(logs.Stderr);
+                }
+                catch
+                {
+                    // do not hide the original exception
+                }
+
+                throw;
+            }
+
+            return new EventGridEmulatorContext(container);
+        }
+
+        private static IContainer BuildContainer(string configurationPath)
+        {
+            return new ContainerBuilder()
+                .WithImage("workleap/eventgridemulator:0.2.0") // TODO Renovate this?
+                .WithPortBinding(6500, assignRandomHostPort: true)
+                .WithBindMount(configurationPath, "/app/appsettings.json", AccessMode.ReadOnly)
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(6500))
+                .Build();
+        }
+
+        private static async Task<string> WriteConfigurationFile(ITestOutputHelper testOutputHelper)
+        {
+            var path = Path.GetTempFileName();
+            await File.WriteAllTextAsync(path, GetConfiguration());
+            if (!OperatingSystem.IsWindows())
+            {
+                await CliWrap.Cli.Wrap("chmod").WithArguments(["0444", path]).ExecuteAsync();
+            }
+            
+            // For debug purposes only
+            testOutputHelper.WriteLine("Write configuration file at: " + path);
+            testOutputHelper.WriteLine("Write configuration content: " + await File.ReadAllTextAsync(path));
+
+            return path;
+        }
+
+        private static string GetConfiguration()
+        {
+            return $$"""
+                     {
+                       "Topics": {
+                         "{{TopicName}}": [
+                           "{{LocalUrl}}{{SubscriberEndpoint}}"
+                         ]
+                       }
+                     }
+                     """;
+        }
+        
+        public async ValueTask DisposeAsync()
+        {
+            await container.DisposeAsync();
+        }
+    }
+}

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Workleap.DomainEventPropagation.Subscription.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Workleap.DomainEventPropagation.Subscription.Tests.csproj
@@ -8,16 +8,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Workleap.DomainEventPropagation.Publishing\Workleap.DomainEventPropagation.Publishing.csproj" />
     <ProjectReference Include="..\Workleap.DomainEventPropagation.Subscription.ApplicationInsights\Workleap.DomainEventPropagation.Subscription.ApplicationInsights.csproj" />
     <ProjectReference Include="..\Workleap.DomainEventPropagation.Subscription\Workleap.DomainEventPropagation.Subscription.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CliWrap" Version="3.6.6" />
     <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="GSoft.Extensions.Xunit" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.20" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="OpenTelemetry" Version="1.7.0" />
+    <PackageReference Include="Testcontainers" Version="3.7.0" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Workleap.DomainEventPropagation.Subscription/DomainEventGridWebhookHandler.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/DomainEventGridWebhookHandler.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
+using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using Microsoft.Extensions.Logging;
 
@@ -47,6 +48,19 @@ internal sealed class DomainEventGridWebhookHandler : BaseEventHandler, IDomainE
         if (this.GetDomainEventType(domainEventWrapper.DomainEventName) == null)
         {
             this._logger.EventDomainTypeNotRegistered(domainEventWrapper.DomainEventName, eventGridEvent.Subject);
+            return;
+        }
+
+        await this._pipeline(domainEventWrapper, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task HandleEventGridWebhookEventAsync(CloudEvent cloudEvent, CancellationToken cancellationToken)
+    {
+        var domainEventWrapper = new DomainEventWrapper(cloudEvent);
+
+        if (this.GetDomainEventType(domainEventWrapper.DomainEventName) == null)
+        {
+            this._logger.EventDomainTypeNotRegistered(domainEventWrapper.DomainEventName, cloudEvent.Source);
             return;
         }
 

--- a/src/Workleap.DomainEventPropagation.Subscription/EndpointRouteBuilderExtensions.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
@@ -10,6 +10,6 @@ public static class EndpointRouteBuilderExtensions
         => MapEventPropagationEndpoint(builder, EventsApi.Routes.DomainEvents);
 
     public static RouteHandlerBuilder MapEventPropagationEndpoint(this IEndpointRouteBuilder builder, string pattern) => builder
-        .MapPost(pattern, EventsApi.HandleEventGridEvents)
+        .MapPost(pattern, EventsApi.HandleEvents)
         .ExcludeFromDescription();
 }

--- a/src/Workleap.DomainEventPropagation.Subscription/EventsApi.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/EventsApi.cs
@@ -26,7 +26,7 @@ internal static class EventsApi
         }
         else
         {
-            return Results.Problem("Unknown payload, only EventGridEvent or CloudEvent are supported", statusCode: 500);
+            throw new NotSupportedException("Unknown payload, only EventGridEvent or CloudEvent are supported");
         }
 
         return result?.RequestType switch

--- a/src/Workleap.DomainEventPropagation.Subscription/EventsApi.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/EventsApi.cs
@@ -1,3 +1,4 @@
+using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -6,18 +7,57 @@ namespace Workleap.DomainEventPropagation;
 
 internal static class EventsApi
 {
-    internal static async Task<IResult> HandleEventGridEvents(
-        [FromBody] EventGridEvent[] eventGridEvents,
+    internal static async Task<IResult> HandleEvents(
+        HttpRequest request,
         [FromServices] IEventGridRequestHandler eventGridRequestHandler,
         CancellationToken cancellationToken)
     {
-        var result = await eventGridRequestHandler.HandleRequestAsync(eventGridEvents, cancellationToken).ConfigureAwait(false);
+        var events = await BinaryData.FromStreamAsync(request.Body, cancellationToken).ConfigureAwait(false);
 
-        return result.RequestType switch
+        EventGridRequestResult? result = null;
+
+        if (TryParseMany(events, out EventGridEvent[] eventGridEvents))
+        {
+            result = await eventGridRequestHandler.HandleRequestAsync(eventGridEvents, cancellationToken).ConfigureAwait(false);
+        }
+        else if (TryParseMany(events, out CloudEvent[] cloudEvents))
+        {
+            result = await eventGridRequestHandler.HandleRequestAsync(cloudEvents, cancellationToken).ConfigureAwait(false);
+        }
+
+        return result?.RequestType switch
         {
             EventGridRequestType.Subscription => Results.Ok(result.ValidationResponse),
             _ => Results.Ok(),
         };
+    }
+
+    private static bool TryParseMany(BinaryData binaryEvents, out EventGridEvent[] events)
+    {
+        try
+        {
+            events = EventGridEvent.ParseMany(binaryEvents);
+            return true;
+        }
+        catch (Exception)
+        {
+            events = [];
+            return false;
+        }
+    }
+
+    private static bool TryParseMany(BinaryData binaryEvents, out CloudEvent[] events)
+    {
+        try
+        {
+            events = CloudEvent.ParseMany(binaryEvents);
+            return true;
+        }
+        catch (Exception)
+        {
+            events = [];
+            return false;
+        }
     }
 
     internal static class Routes

--- a/src/Workleap.DomainEventPropagation.Subscription/EventsApi.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/EventsApi.cs
@@ -24,6 +24,10 @@ internal static class EventsApi
         {
             result = await eventGridRequestHandler.HandleRequestAsync(cloudEvents, cancellationToken).ConfigureAwait(false);
         }
+        else
+        {
+            return Results.StatusCode(500);
+        }
 
         return result?.RequestType switch
         {

--- a/src/Workleap.DomainEventPropagation.Subscription/EventsApi.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/EventsApi.cs
@@ -26,7 +26,7 @@ internal static class EventsApi
         }
         else
         {
-            return Results.StatusCode(500);
+            return Results.Problem("Unknown payload, only EventGridEvent or CloudEvent are supported", statusCode: 500);
         }
 
         return result?.RequestType switch

--- a/src/Workleap.DomainEventPropagation.Subscription/IDomainEventGridWebhookHandler.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/IDomainEventGridWebhookHandler.cs
@@ -1,3 +1,4 @@
+using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 
 namespace Workleap.DomainEventPropagation;
@@ -5,4 +6,6 @@ namespace Workleap.DomainEventPropagation;
 internal interface IDomainEventGridWebhookHandler
 {
     Task HandleEventGridWebhookEventAsync(EventGridEvent eventGridEvent, CancellationToken cancellationToken);
+
+    Task HandleEventGridWebhookEventAsync(CloudEvent cloudEvent, CancellationToken cancellationToken);
 }

--- a/src/Workleap.DomainEventPropagation.Subscription/IEventGridRequestHandler.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription/IEventGridRequestHandler.cs
@@ -1,3 +1,4 @@
+using Azure.Messaging;
 using Azure.Messaging.EventGrid;
 
 namespace Workleap.DomainEventPropagation;
@@ -5,4 +6,6 @@ namespace Workleap.DomainEventPropagation;
 internal interface IEventGridRequestHandler
 {
     Task<EventGridRequestResult> HandleRequestAsync(EventGridEvent[] eventGridEvents, CancellationToken cancellationToken);
+
+    Task<EventGridRequestResult> HandleRequestAsync(CloudEvent[] cloudEvents, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
## Description of changes
- Added the capacity to send CloudEvents to a custom EventGrid topic
- Added the capacity to receive CloudEvents through the webhook endpoint

## Breaking changes
This is backwards compatible

## Additional checks
- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
