### PR TITLE
Adding support to override CloudEvents metadata when publishing an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ var domainEvent = new ExampleDomainEvent
 await this._eventPropagationClient.PublishDomainEventAsync(domainEvent, CancellationToken.None);
 ```
 
+It is possible to specify additional metadata on your domain events to allow leveraging the subscription filtering within Azure.
+*This is only supported on domain events that use the CloudEvent schema.*
+
+```csharp
+var domainEvent = new ExampleDomainEvent
+{
+    Id = Guid.NewGuid().ToString()
+};
+
+await this._eventPropagationClient.PublishDomainEventAsync(domainEvent, x => x.Subject = "<custom_subject>", CancellationToken.None);
+```
+
 
 ### Subscribe to domain events with push delivery
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ var domainEvent = new ExampleDomainEvent
 await this._eventPropagationClient.PublishDomainEventAsync(domainEvent, CancellationToken.None);
 ```
 
-It is possible to specify additional metadata on your domain events to allow leveraging the subscription filtering within Azure.
+You can specify additional metadata for your domain events to leverage subscription filtering within Azure.
 *This is only supported on domain events that use the CloudEvent schema.*
 
 ```csharp

--- a/src/Shared/DomainEventMetadataWrapper.cs
+++ b/src/Shared/DomainEventMetadataWrapper.cs
@@ -1,0 +1,55 @@
+using Azure.Messaging;
+
+namespace Workleap.DomainEventPropagation;
+
+/// <summary>
+/// This class is a wrapper around <see cref="CloudEvent"/> to implement <see cref="IDomainEventMetadata"/>.
+/// The goal is to expose the properties of a <see cref="CloudEvent"/> without adding Azure.Messaging as a dependency in the Abstractions project.
+/// </summary>
+internal sealed class DomainEventMetadataWrapper : IDomainEventMetadata
+{
+    private readonly CloudEvent _cloudEvent;
+
+    public DomainEventMetadataWrapper(CloudEvent cloudEvent)
+    {
+        this._cloudEvent = cloudEvent;
+    }
+
+    public string Id
+    {
+        get => this._cloudEvent.Id;
+        set => this._cloudEvent.Id = value;
+    }
+
+    public string Source
+    {
+        get => this._cloudEvent.Source;
+        set => this._cloudEvent.Source = value;
+    }
+
+    public string Type
+    {
+        get => this._cloudEvent.Source;
+        set => this._cloudEvent.Source = value;
+    }
+
+    public DateTimeOffset? Time
+    {
+        get => this._cloudEvent.Time;
+        set => this._cloudEvent.Time = value;
+    }
+
+    public string? DataSchema
+    {
+        get => this._cloudEvent.DataSchema;
+        set => this._cloudEvent.DataSchema = value;
+    }
+
+    public string? Subject
+    {
+        get => this._cloudEvent.Subject;
+        set => this._cloudEvent.Subject = value;
+    }
+
+    public IDictionary<string, object> ExtensionAttributes => this._cloudEvent.ExtensionAttributes;
+}

--- a/src/Shared/DomainEventWrapperCollection.cs
+++ b/src/Shared/DomainEventWrapperCollection.cs
@@ -6,12 +6,12 @@ internal sealed class DomainEventWrapperCollection : IReadOnlyCollection<DomainE
 {
     private readonly DomainEventWrapper[] _domainEventWrappers;
 
-    private DomainEventWrapperCollection(IEnumerable<DomainEventWrapper> domainEventWrappers, Action<IDomainEventMetadata>? domainEventConfiguration, string domainEventName, EventSchema schema)
+    private DomainEventWrapperCollection(IEnumerable<DomainEventWrapper> domainEventWrappers, Action<IDomainEventMetadata>? configureDomainEventMetadata, string domainEventName, EventSchema schema)
     {
         this._domainEventWrappers = domainEventWrappers.ToArray();
         this.DomainEventName = domainEventName;
         this.DomainSchema = schema;
-        this.DomainEventConfiguration = domainEventConfiguration;
+        this.ConfigureDomainEventMetadata = configureDomainEventMetadata;
     }
 
     public int Count => this._domainEventWrappers.Length;
@@ -20,14 +20,14 @@ internal sealed class DomainEventWrapperCollection : IReadOnlyCollection<DomainE
 
     public EventSchema DomainSchema { get; }
 
-    public Action<IDomainEventMetadata>? DomainEventConfiguration { get; }
+    public Action<IDomainEventMetadata>? ConfigureDomainEventMetadata { get; }
 
-    public static DomainEventWrapperCollection Create<T>(IEnumerable<T> domainEvents, Action<IDomainEventMetadata>? domainEventConfiguration)
+    public static DomainEventWrapperCollection Create<T>(IEnumerable<T> domainEvents, Action<IDomainEventMetadata>? configureDomainEventMetadata)
         where T : IDomainEvent
     {
         var domainEventWrappers = domainEvents.Select(DomainEventWrapper.Wrap).ToArray();
         
-        return new DomainEventWrapperCollection(domainEventWrappers, domainEventConfiguration, DomainEventNameCache.GetName<T>(), DomainEventSchemaCache.GetEventSchema<T>());
+        return new DomainEventWrapperCollection(domainEventWrappers, configureDomainEventMetadata, DomainEventNameCache.GetName<T>(), DomainEventSchemaCache.GetEventSchema<T>());
     }
 
     public IEnumerator<DomainEventWrapper> GetEnumerator()

--- a/src/Shared/DomainEventWrapperCollection.cs
+++ b/src/Shared/DomainEventWrapperCollection.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 
 namespace Workleap.DomainEventPropagation;
 
@@ -6,11 +6,12 @@ internal sealed class DomainEventWrapperCollection : IReadOnlyCollection<DomainE
 {
     private readonly DomainEventWrapper[] _domainEventWrappers;
 
-    private DomainEventWrapperCollection(IEnumerable<DomainEventWrapper> domainEventWrappers, string domainEventName, EventSchema schema)
+    private DomainEventWrapperCollection(IEnumerable<DomainEventWrapper> domainEventWrappers, Action<IDomainEventMetadata>? domainEventConfiguration, string domainEventName, EventSchema schema)
     {
         this._domainEventWrappers = domainEventWrappers.ToArray();
         this.DomainEventName = domainEventName;
         this.DomainSchema = schema;
+        this.DomainEventConfiguration = domainEventConfiguration;
     }
 
     public int Count => this._domainEventWrappers.Length;
@@ -19,12 +20,14 @@ internal sealed class DomainEventWrapperCollection : IReadOnlyCollection<DomainE
 
     public EventSchema DomainSchema { get; }
 
-    public static DomainEventWrapperCollection Create<T>(IEnumerable<T> domainEvents)
+    public Action<IDomainEventMetadata>? DomainEventConfiguration { get; }
+
+    public static DomainEventWrapperCollection Create<T>(IEnumerable<T> domainEvents, Action<IDomainEventMetadata>? domainEventConfiguration)
         where T : IDomainEvent
     {
         var domainEventWrappers = domainEvents.Select(DomainEventWrapper.Wrap).ToArray();
         
-        return new DomainEventWrapperCollection(domainEventWrappers, DomainEventNameCache.GetName<T>(), DomainEventSchemaCache.GetEventSchema<T>());
+        return new DomainEventWrapperCollection(domainEventWrappers, domainEventConfiguration, DomainEventNameCache.GetName<T>(), DomainEventSchemaCache.GetEventSchema<T>());
     }
 
     public IEnumerator<DomainEventWrapper> GetEnumerator()

--- a/src/Workleap.DomainEventPropagation.Abstractions/IDomainEventMetadata.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/IDomainEventMetadata.cs
@@ -1,0 +1,18 @@
+namespace Workleap.DomainEventPropagation;
+
+public interface IDomainEventMetadata
+{
+    string Id { get; set; }
+
+    string Source { get; set; }
+
+    string Type { get; set; }
+
+    DateTimeOffset? Time { get; set; }
+
+    string? DataSchema { get; set; }
+
+    string? Subject { get; set; }
+
+    IDictionary<string, object> ExtensionAttributes { get; }
+}

--- a/src/Workleap.DomainEventPropagation.Abstractions/IEventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/IEventPropagationClient.cs
@@ -5,12 +5,12 @@ public interface IEventPropagationClient
     Task PublishDomainEventAsync<T>(T domainEvent, CancellationToken cancellationToken)
         where T : IDomainEvent;
 
-    Task PublishDomainEventAsync<T>(T domainEvent, Action<IDomainEventMetadata> domainEventConfiguration, CancellationToken cancellationToken)
+    Task PublishDomainEventAsync<T>(T domainEvent, Action<IDomainEventMetadata> configureDomainEventMetadata, CancellationToken cancellationToken)
         where T : IDomainEvent;
 
     Task PublishDomainEventsAsync<T>(IEnumerable<T> domainEvents, CancellationToken cancellationToken)
         where T : IDomainEvent;
 
-    Task PublishDomainEventsAsync<T>(IEnumerable<T> domainEvents, Action<IDomainEventMetadata> domainEventConfiguration, CancellationToken cancellationToken)
+    Task PublishDomainEventsAsync<T>(IEnumerable<T> domainEvents, Action<IDomainEventMetadata> configureDomainEventMetadata, CancellationToken cancellationToken)
         where T : IDomainEvent;
 }

--- a/src/Workleap.DomainEventPropagation.Abstractions/IEventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Abstractions/IEventPropagationClient.cs
@@ -5,6 +5,12 @@ public interface IEventPropagationClient
     Task PublishDomainEventAsync<T>(T domainEvent, CancellationToken cancellationToken)
         where T : IDomainEvent;
 
+    Task PublishDomainEventAsync<T>(T domainEvent, Action<IDomainEventMetadata> domainEventConfiguration, CancellationToken cancellationToken)
+        where T : IDomainEvent;
+
     Task PublishDomainEventsAsync<T>(IEnumerable<T> domainEvents, CancellationToken cancellationToken)
+        where T : IDomainEvent;
+
+    Task PublishDomainEventsAsync<T>(IEnumerable<T> domainEvents, Action<IDomainEventMetadata> domainEventConfiguration, CancellationToken cancellationToken)
         where T : IDomainEvent;
 }

--- a/src/Workleap.DomainEventPropagation.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Workleap.DomainEventPropagation.Abstractions/PublicAPI.Shipped.txt
@@ -11,6 +11,22 @@ Workleap.DomainEventPropagation.EventSchema.CloudEvent = 2 -> Workleap.DomainEve
 Workleap.DomainEventPropagation.IDomainEvent
 Workleap.DomainEventPropagation.IDomainEventHandler<TDomainEvent>
 Workleap.DomainEventPropagation.IDomainEventHandler<TDomainEvent>.HandleDomainEventAsync(TDomainEvent domainEvent, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Workleap.DomainEventPropagation.IDomainEventMetadata
+Workleap.DomainEventPropagation.IDomainEventMetadata.DataSchema.get -> string?
+Workleap.DomainEventPropagation.IDomainEventMetadata.DataSchema.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.ExtensionAttributes.get -> System.Collections.Generic.IDictionary<string!, object!>!
+Workleap.DomainEventPropagation.IDomainEventMetadata.Id.get -> string!
+Workleap.DomainEventPropagation.IDomainEventMetadata.Id.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.Source.get -> string!
+Workleap.DomainEventPropagation.IDomainEventMetadata.Source.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.Subject.get -> string?
+Workleap.DomainEventPropagation.IDomainEventMetadata.Subject.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.Time.get -> System.DateTimeOffset?
+Workleap.DomainEventPropagation.IDomainEventMetadata.Time.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.Type.get -> string!
+Workleap.DomainEventPropagation.IDomainEventMetadata.Type.set -> void
 Workleap.DomainEventPropagation.IEventPropagationClient
 Workleap.DomainEventPropagation.IEventPropagationClient.PublishDomainEventAsync<T>(T domainEvent, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Workleap.DomainEventPropagation.IEventPropagationClient.PublishDomainEventAsync<T>(T domainEvent, System.Action<Workleap.DomainEventPropagation.IDomainEventMetadata!>! configureDomainEventMetadata, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Workleap.DomainEventPropagation.IEventPropagationClient.PublishDomainEventsAsync<T>(System.Collections.Generic.IEnumerable<T>! domainEvents, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Workleap.DomainEventPropagation.IEventPropagationClient.PublishDomainEventsAsync<T>(System.Collections.Generic.IEnumerable<T>! domainEvents, System.Action<Workleap.DomainEventPropagation.IDomainEventMetadata!>! configureDomainEventMetadata, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/src/Workleap.DomainEventPropagation.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Workleap.DomainEventPropagation.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,17 @@
 #nullable enable
+Workleap.DomainEventPropagation.IDomainEventMetadata
+Workleap.DomainEventPropagation.IDomainEventMetadata.DataSchema.get -> string?
+Workleap.DomainEventPropagation.IDomainEventMetadata.DataSchema.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.ExtensionAttributes.get -> System.Collections.Generic.IDictionary<string!, object!>!
+Workleap.DomainEventPropagation.IDomainEventMetadata.Id.get -> string!
+Workleap.DomainEventPropagation.IDomainEventMetadata.Id.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.Source.get -> string!
+Workleap.DomainEventPropagation.IDomainEventMetadata.Source.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.Subject.get -> string?
+Workleap.DomainEventPropagation.IDomainEventMetadata.Subject.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.Time.get -> System.DateTimeOffset?
+Workleap.DomainEventPropagation.IDomainEventMetadata.Time.set -> void
+Workleap.DomainEventPropagation.IDomainEventMetadata.Type.get -> string!
+Workleap.DomainEventPropagation.IDomainEventMetadata.Type.set -> void
+Workleap.DomainEventPropagation.IEventPropagationClient.PublishDomainEventAsync<T>(T domainEvent, System.Action<Workleap.DomainEventPropagation.IDomainEventMetadata!>! domainEventConfiguration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Workleap.DomainEventPropagation.IEventPropagationClient.PublishDomainEventsAsync<T>(System.Collections.Generic.IEnumerable<T>! domainEvents, System.Action<Workleap.DomainEventPropagation.IDomainEventMetadata!>! domainEventConfiguration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/src/Workleap.DomainEventPropagation.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Workleap.DomainEventPropagation.Abstractions/PublicAPI.Unshipped.txt
@@ -1,17 +1,1 @@
 #nullable enable
-Workleap.DomainEventPropagation.IDomainEventMetadata
-Workleap.DomainEventPropagation.IDomainEventMetadata.DataSchema.get -> string?
-Workleap.DomainEventPropagation.IDomainEventMetadata.DataSchema.set -> void
-Workleap.DomainEventPropagation.IDomainEventMetadata.ExtensionAttributes.get -> System.Collections.Generic.IDictionary<string!, object!>!
-Workleap.DomainEventPropagation.IDomainEventMetadata.Id.get -> string!
-Workleap.DomainEventPropagation.IDomainEventMetadata.Id.set -> void
-Workleap.DomainEventPropagation.IDomainEventMetadata.Source.get -> string!
-Workleap.DomainEventPropagation.IDomainEventMetadata.Source.set -> void
-Workleap.DomainEventPropagation.IDomainEventMetadata.Subject.get -> string?
-Workleap.DomainEventPropagation.IDomainEventMetadata.Subject.set -> void
-Workleap.DomainEventPropagation.IDomainEventMetadata.Time.get -> System.DateTimeOffset?
-Workleap.DomainEventPropagation.IDomainEventMetadata.Time.set -> void
-Workleap.DomainEventPropagation.IDomainEventMetadata.Type.get -> string!
-Workleap.DomainEventPropagation.IDomainEventMetadata.Type.set -> void
-Workleap.DomainEventPropagation.IEventPropagationClient.PublishDomainEventAsync<T>(T domainEvent, System.Action<Workleap.DomainEventPropagation.IDomainEventMetadata!>! domainEventConfiguration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-Workleap.DomainEventPropagation.IEventPropagationClient.PublishDomainEventsAsync<T>(System.Collections.Generic.IEnumerable<T>! domainEvents, System.Action<Workleap.DomainEventPropagation.IDomainEventMetadata!>! domainEventConfiguration, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\DomainEventWrapper.cs" Link="Shared\DomainEventWrapper.cs" />
+    <Compile Include="..\Shared\DomainEventMetadataWrapper.cs" Link="Shared\DomainEventMetadataWrapper.cs" />
     <Compile Include="..\Shared\DomainEventWrapperCollection.cs" Link="Shared\DomainEventWrapperCollection.cs" />
     <Compile Include="..\Shared\JsonSerializerConstants.cs" Link="Shared\JsonSerializerConstants.cs" />
     <Compile Include="..\Shared\TracingHelper.cs" Link="Shared\TracingHelper.cs" />


### PR DESCRIPTION
## Description of changes
An optional configuration can now be specified when dispatching domain events, allowing to control the CloudEvents metadata fields. EventGridEvents are not supported.

## Breaking changes
This is only adding an optional parameter, it remains backwards compatible

## Additional checks
- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
