### PR TITLE
[IDP-1152] Upgrade Microsoft.Extensions.Azure to v1.7.2

### DIFF
--- a/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.22.0-beta.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
@@ -11,13 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.22.0-beta.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />


### PR DESCRIPTION
## Description of changes
We need to upgrade Azure.Identity away from v1.10.4. This library is implicitly referenced by Microsoft.Extensions.Azure

## Breaking changes
None that impacts our library.

## Additional checks


- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
