### PR TITLE
[IDP-1152] Allow publishing stable version when referencing prerelease

### DIFF
--- a/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
@@ -8,6 +8,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../Workleap.DomainEventPropagation.snk</AssemblyOriginatorKeyFile>
     <RootNamespace>Workleap.DomainEventPropagation</RootNamespace>
+    <!-- This allows us to publish with a prerelease nuget -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/Workleap.DomainEventPropagation.Subscription.PullDelivery.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/Workleap.DomainEventPropagation.Subscription.PullDelivery.csproj
@@ -8,8 +8,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../Workleap.DomainEventPropagation.snk</AssemblyOriginatorKeyFile>
     <RootNamespace>Workleap.DomainEventPropagation</RootNamespace>
-    <!-- This .NET error has been fixed in .NET 7 -->
-    <NoWarn>$(NoWarn);AD0001</NoWarn>
+    <!-- This allows us to publish with a prerelease nuget -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description of changes
Allow publishing of stable version even when referencing prerelease nuget (necessary given Pull Delivery is still in preview).

## Breaking changes
None

## Additional checks

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
