### PR TITLE
Ignore Azure.Messaging.EventGrid nuget in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,12 @@
       "enabled": false
     },
     {
+      "matchManagers": ["nuget"],
+      "excludePackageNames": ["Azure.Messaging.EventGrid"],
+      "description": "We want to avoid updates to Azure.Messaging.EventGrid versions given that Pull delivery API for CloudEvents is only supported on the beta versions.",
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["dotnet-sdk"],
       "groupName": "Dotnet SDK",
       "description": "Only update patch and minor for the dotnet SDK version within the global.json",
@@ -54,7 +60,7 @@
       "fileMatch": ["\\.cs$"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "WithImage(\"(?<imageName>.*?):(?<version>.*?)\")"
+        "WithImage(\"(?<depName>.*?):(?<currentValue>.*?)\")"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"


### PR DESCRIPTION
## Description of changes
This library supports Pull delivery model for CloudEvent schema with EventGrid. However, it is still a preview feature and only supported as part of a beta version. Thus, we should only update the nuget version once the feature is release or there is a new beta version of the library which supports Pull delivery.

## Breaking changes
None