### PR TITLE
Add Parallelization when handling Domain Events with Pull Delivery

### DIFF
--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading.Channels;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
@@ -14,6 +15,7 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
     private const string TopicName = "Topic1";
     private const string SubscriberName = "subscriber1";
     private const int EventId = 1;
+    private const int SlowHandlerDelay = 250;
     
     [Fact]
     public async Task TestPublishAndReceiveEvent()
@@ -28,7 +30,7 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
         await using var eventGridEmulator = await EventGridEmulatorContext.StartAsync(testOutputHelper);
         
         // Configure the publisher and the subscriptions, and start the service
-        var host = this.BuildHost(eventGridEmulator.Url);
+        var host = this.BuildHost<TestDomainEventHandler>(eventGridEmulator.Url);
         var runTask = host.RunAsync(cts.Token); // The method returns when the services are running
         
         // Send an event
@@ -47,12 +49,55 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
         await runTask;
     }
 
-    private IHost BuildHost(string eventGridUrl)
+    [Theory]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(1000)]
+    [InlineData(10000)]
+    public async Task TestHeavyLoadOfEvents(int eventCount)
+    {
+        // Add a timeout for the test to not block indefinitely
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+
+        // Start Event Grid Emulator
+        await using var eventGridEmulator = await EventGridEmulatorContext.StartAsync(testOutputHelper);
+
+        // Configure the publisher and the subscriptions, and start the service
+        var host = this.BuildHost<SlowTestDomainEventHandler>(eventGridEmulator.Url);
+        var runTask = host.RunAsync(cts.Token); // The method returns when the services are running
+
+        // Get the event processing output. The background service should call SlowTestDomainEventHandler, so the data should get updated
+        var eventProcessingOutput = host.Services.GetRequiredService<EventProcessingOutput>();
+
+        // Send many events
+        var client = host.Services.GetRequiredService<IEventPropagationClient>();
+        var eventBatches = Enumerable.Range(0, eventCount)
+            .Chunk(1000)
+            .Select(x => x.Select(id => new TestEvent { Id = id }).ToList());
+
+        foreach (var eventBatch in eventBatches)
+        {
+            eventProcessingOutput.IncrementTotal(eventBatch.Count);
+            await client.PublishDomainEventsAsync(eventBatch, cts.Token);
+        }
+
+        // Wait for all events to be processed
+        await eventProcessingOutput.WaitForCompletion(cts.Token);
+        testOutputHelper.WriteLine($"Processed {eventProcessingOutput.Count} out of {eventProcessingOutput.Total} events in {eventProcessingOutput.Duration.TotalMilliseconds} ms ({eventProcessingOutput.EventsPerSecond:F} event/second) with handler execution time at {SlowHandlerDelay} ms");
+        Assert.True(eventProcessingOutput.EventsPerSecond > 1m / SlowHandlerDelay);
+
+        // Terminate the service
+        host.Services.GetRequiredService<IHostApplicationLifetime>().StopApplication();
+        await runTask;
+    }
+
+    private IHost BuildHost<T>(string eventGridUrl) where T : class, IDomainEventHandler<TestEvent>
     {
         IHostBuilder? builder = Host.CreateDefaultBuilder();
         builder.ConfigureServices(services =>
         {
             services.AddSingleton(Channel.CreateUnbounded<TestEvent>());
+            services.AddSingleton<EventProcessingOutput>();
             services.AddEventPropagationPublisher(options =>
             {
                 options.TopicEndpoint = eventGridUrl;
@@ -67,8 +112,9 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
                     options.TopicName = TopicName;
                     options.SubscriptionName = SubscriberName;
                     options.TopicAccessKey = "noop";
+                    options.MaxDop = 500;
                 })
-                .AddDomainEventHandler<TestEvent, TestDomainEventHandler>();
+                .AddDomainEventHandler<TestEvent, T>();
         });
 
         return builder.Build();
@@ -85,6 +131,16 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
         public async Task HandleDomainEventAsync(TestEvent domainEvent, CancellationToken cancellationToken)
         {
             await channel.Writer.WriteAsync(domainEvent, cancellationToken);
+        }
+    }
+
+    private sealed class SlowTestDomainEventHandler(EventProcessingOutput eventProcessingOutput) : IDomainEventHandler<TestEvent>
+    {
+        public async Task HandleDomainEventAsync(TestEvent domainEvent, CancellationToken cancellationToken)
+        {
+            eventProcessingOutput.StartProcessing();
+            await Task.Delay(SlowHandlerDelay, cancellationToken);
+            eventProcessingOutput.IncrementCount();
         }
     }
 
@@ -163,6 +219,56 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
         public async ValueTask DisposeAsync()
         {
             await container.DisposeAsync();
+        }
+    }
+
+    private sealed class EventProcessingOutput
+    {
+        private readonly object _lock = new();
+
+        private readonly TaskCompletionSource _taskCompletionSource = new();
+
+        private Stopwatch? _stopWatch;
+
+        public int Count { get; private set; }
+
+        public int Total { get; private set; }
+
+        public TimeSpan Duration { get; private set; }
+
+        public decimal EventsPerSecond => this.Count / (decimal)this.Duration.TotalSeconds;
+
+        public void IncrementCount()
+        {
+            lock (this._lock)
+            {
+                this.Count++;
+
+                if (this.Count == this.Total)
+                {
+                    this.Duration = this._stopWatch?.Elapsed ?? TimeSpan.Zero;
+                    this._taskCompletionSource.TrySetResult();
+                }
+            }
+        }
+
+        public void IncrementTotal(int incrementSize)
+        {
+            lock (this._lock)
+            {
+                this.Total += incrementSize;
+            }
+        }
+
+        public void StartProcessing()
+        {
+            this._stopWatch ??= Stopwatch.StartNew();
+        }
+
+        public Task WaitForCompletion(CancellationToken cancellationToken)
+        {
+            cancellationToken.Register(() => this._taskCompletionSource.TrySetCanceled(cancellationToken));
+            return this._taskCompletionSource.Task;
         }
     }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/TaskBoundedChannelTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/TaskBoundedChannelTests.cs
@@ -1,0 +1,478 @@
+using System.Diagnostics;
+using System.Threading.Channels;
+
+namespace Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests;
+
+public class TaskBoundedChannelTests
+{
+    private const int DefaultTaskDelay = 300;
+
+    private Channel<Task>? _taskChannel;
+    private int _channelCapacity;
+    private bool _tryWriteResult;
+    private bool _tryReadResult;
+    private Task? _tryReadTaskResult;
+    private bool _waitToWriteAsyncResult;
+    private long _waitToWriteAsyncDelay;
+    private long _writeAsyncDelay;
+    private long _readAsyncDelay;
+    private Task? _readAsyncResult;
+    private bool _readWasCancelled;
+    private List<Task>? _readAllAsyncResult;
+    private long _readAllAsyncDelay;
+    private bool _readAllWasCancelled;
+    private bool _waitToReadAsyncResult;
+    private long _waitToReadAsyncDelay;
+    private bool _waitToReadWasCancelled;
+    private List<Task>? _variedTasks;
+
+    [Fact]
+    public void GivenBoundedTaskChannel_WhenTryWrite_ThenReturnTrue()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+
+        // When
+        this.WhenTryWrite(Task.Delay(5));
+
+        // Then
+        this.ThenTryWriteResultShouldBeTrue();
+    }
+
+    [Fact]
+    public void GivenMaxedCapacityBoundedTaskChannel_WhenTryWrite_ThenReturnFalse()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+        this.GivenChannelAlreadyHasATaskAmountOf(10);
+
+        // When
+        this.WhenTryWrite(Task.Delay(5));
+
+        // Then
+        this.ThenTryWriteResultShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task GivenBoundedTaskChannel_WhenWaitToWriteAsync_ThenReturnImmediately()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+
+        // When
+        await this.WhenWaitToWriteAsync();
+
+        // Then
+        this.ThenWaitToWriteAsyncResultShouldBeTrue();
+        this.ThenWaitToWriteAsyncResultShouldBeImmediate();
+    }
+
+    [Fact]
+    public async Task GivenMaxedCapacityBoundedTaskChannel_WhenWaitToWriteAsync_ThenReturnAfterRead()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+        this.GivenChannelAlreadyHasATaskAmountOf(10);
+
+        // When
+        await this.WhenWaitToWriteAsync();
+
+        // Then
+        this.ThenWaitToWriteAsyncResultShouldBeTrue();
+        this.ThenWaitToWriteAsyncResultShouldWaitForTasks();
+    }
+
+    [Fact]
+    public async Task GivenBoundedTaskChannel_WhenWriteAsync_ThenReturnImmediately()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+
+        // When
+        await this.WhenWriteAsync();
+
+        // Then
+        this.ThenWriteAsyncResultShouldBeImmediate();
+    }
+
+    [Fact]
+    public async Task GivenMaxedCapacityBoundedTaskChannel_WhenWriteAsync_ThenReturnAfterRead()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+        this.GivenChannelAlreadyHasATaskAmountOf(10);
+
+        // When
+        await this.WhenWriteAsync();
+
+        // Then
+        this.ThenWriteAsyncResultShouldWaitForTasks();
+    }
+
+    [Fact]
+    public void GivenEmptyBoundedTaskChannel_WhenTryRead_ThenReturnFalse()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+
+        // When
+        this.WhenTryRead();
+
+        // Then
+        this.ThenTryReadResultShouldBeFalse();
+        this.ThenTryReadTaskResultShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenNonEmptyBoundedTaskChannel_WhenTryRead_ThenReturnFalse()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+        this.GivenChannelAlreadyHasATaskAmountOf(1);
+
+        // When
+        this.WhenTryRead();
+
+        // Then
+        this.ThenTryReadResultShouldBeFalse();
+        this.ThenTryReadTaskResultShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GivenEmptyBoundedTaskChannel_WhenReadAsync_ThenReturnNothingAndExpire()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+
+        // When
+        await this.WhenReadAsync();
+
+        // Then
+        this.ThenReadAsyncShouldNotReturnTask();
+        this.ThenReadAsyncResultShouldExpire();
+    }
+
+    [Fact]
+    public async Task GivenNonEmptyBoundedTaskChannel_WhenReadAsync_ThenReturnAfterTaskDelay()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+        this.GivenChannelAlreadyHasATaskAmountOf(1);
+
+        // When
+        await this.WhenReadAsync();
+
+        // Then
+        this.ThenReadAsyncShouldReturnTask();
+        this.ThenReadAsyncResultShouldWaitForTasks();
+    }
+
+    [Fact]
+    public async Task GivenEmptyBoundedTaskChannel_WhenReadAllAsync_ThenReturnNothingAndExpire()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+
+        // When
+        await this.WhenReadAllAsync();
+
+        // Then
+        this.ThenReadAllAsyncShouldNotReturnTask();
+        this.ThenReadAllAsyncResultShouldExpire();
+    }
+
+    [Fact]
+    public async Task GivenNonEmptyBoundedTaskChannel_WhenReadAllAsync_ThenReturnAfterTaskDelay()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+        this.GivenChannelAlreadyHasATaskAmountOf(1);
+
+        // When
+        await this.WhenReadAllAsync();
+
+        // Then
+        this.ThenReadAllAsyncShouldReturnTasks();
+        this.ThenReadAllAsyncResultShouldWaitForTasks();
+    }
+
+    [Fact]
+    public async Task GivenEmptyBoundedTaskChannel_WhenWaitToReadAsync_ThenReturnNothingAndExpire()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+
+        // When
+        await this.WhenWaitToReadAsync();
+
+        // Then
+        this.ThenWaitToReadAsyncShouldBeFalse();
+        this.ThenWaitToReadAsyncResultShouldExpire();
+    }
+
+    [Fact]
+    public async Task GivenNonEmptyBoundedTaskChannel_WhenWaitToReadAsync_ThenReturnAfterTaskDelay()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+        this.GivenChannelAlreadyHasATaskAmountOf(1);
+
+        // When
+        await this.WhenWaitToReadAsync();
+
+        // Then
+        this.ThenWaitToReadAsyncShouldBeTrue();
+        this.ThenWaitToReadAsyncResultShouldWaitForTasks();
+    }
+
+    [Fact]
+    public async Task GivenNonEmptyBoundedTaskChannel_WhenReadAllAsync_ThenReturnTasksInOrderOfCompletion()
+    {
+        // Given
+        this.GivenBoundedTaskChannelLimitedTo(10);
+        this.GivenChannelHasTasksWithVariedCompletionDelay();
+
+        // When
+        await this.WhenReadAllAsync(DefaultTaskDelay * 10);
+
+        // Then
+        this.ThenReadAllAsyncShouldReturnTasks();
+        this.ThenReadAllAsyncResultShouldBeOrderedTasks();
+    }
+
+    private void GivenBoundedTaskChannelLimitedTo(int capacity)
+    {
+        this._channelCapacity = capacity;
+        this._taskChannel = new TaskBoundedChannel<Task>(this._channelCapacity);
+    }
+
+    private void GivenChannelAlreadyHasATaskAmountOf(int existingTaskAmount)
+    {
+        for (var i = 0; i < existingTaskAmount; i++)
+        {
+            this._taskChannel!.Writer.TryWrite(Task.Delay(DefaultTaskDelay));
+        }
+    }
+
+    private void GivenChannelHasTasksWithVariedCompletionDelay()
+    {
+        this._variedTasks =
+        [
+            Task.Delay(DefaultTaskDelay * 4),
+            Task.Delay(DefaultTaskDelay * 3),
+            Task.Delay(DefaultTaskDelay * 1),
+            Task.Delay(DefaultTaskDelay * 5),
+            Task.Delay(DefaultTaskDelay * 2)
+        ];
+
+        foreach (var task in this._variedTasks)
+        {
+            this._taskChannel!.Writer.TryWrite(task);
+        }
+    }
+
+    private void WhenTryWrite(Task task)
+    {
+        this._tryWriteResult = this._taskChannel!.Writer.TryWrite(task);
+    }
+
+    private async Task WhenWriteAsync()
+    {
+        var stopWatch = Stopwatch.StartNew();
+        await this._taskChannel!.Writer.WriteAsync(Task.Delay(DefaultTaskDelay));
+        this._writeAsyncDelay = stopWatch.ElapsedMilliseconds;
+    }
+
+    private async Task WhenWaitToWriteAsync()
+    {
+        var stopWatch = Stopwatch.StartNew();
+        this._waitToWriteAsyncResult = await this._taskChannel!.Writer.WaitToWriteAsync();
+        this._waitToWriteAsyncDelay = stopWatch.ElapsedMilliseconds;
+    }
+
+    private void WhenTryRead()
+    {
+        this._tryReadResult = this._taskChannel!.Reader.TryRead(out this._tryReadTaskResult);
+    }
+
+    private async Task WhenReadAsync()
+    {
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(DefaultTaskDelay * 2);
+
+        var stopWatch = Stopwatch.StartNew();
+        try
+        {
+            this._readAsyncResult = await this._taskChannel!.Reader.ReadAsync(cts.Token);
+            this._readAsyncDelay = stopWatch.ElapsedMilliseconds;
+        }
+        catch (OperationCanceledException)
+        {
+            this._readWasCancelled = true;
+            this._readAsyncDelay = stopWatch.ElapsedMilliseconds;
+        }
+    }
+
+    private async Task WhenReadAllAsync(int maxDelay = DefaultTaskDelay * 2)
+    {
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(maxDelay);
+
+        var stopWatch = Stopwatch.StartNew();
+        try
+        {
+            await foreach (var task in this._taskChannel!.Reader.ReadAllAsync(cts.Token))
+            {
+                this._readAllAsyncResult ??= [];
+                this._readAllAsyncResult.Add(task);
+            }
+
+            this._readAllAsyncDelay = stopWatch.ElapsedMilliseconds;
+        }
+        catch (OperationCanceledException)
+        {
+            this._readAllWasCancelled = true;
+            this._readAllAsyncDelay = stopWatch.ElapsedMilliseconds;
+        }
+    }
+
+    private async Task WhenWaitToReadAsync()
+    {
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(DefaultTaskDelay * 2);
+
+        var stopWatch = Stopwatch.StartNew();
+        try
+        {
+            this._waitToReadAsyncResult = await this._taskChannel!.Reader.WaitToReadAsync(cts.Token);
+            this._waitToReadAsyncDelay = stopWatch.ElapsedMilliseconds;
+        }
+        catch (OperationCanceledException)
+        {
+            this._waitToReadWasCancelled = true;
+            this._waitToReadAsyncDelay = stopWatch.ElapsedMilliseconds;
+        }
+    }
+
+    private void ThenTryWriteResultShouldBeFalse()
+    {
+        Assert.False(this._tryWriteResult);
+    }
+
+    private void ThenTryWriteResultShouldBeTrue()
+    {
+        Assert.True(this._tryWriteResult);
+    }
+
+    private void ThenWaitToWriteAsyncResultShouldBeTrue()
+    {
+        Assert.True(this._waitToWriteAsyncResult);
+    }
+
+    private void ThenWaitToWriteAsyncResultShouldBeImmediate()
+    {
+        // Using 20% of the default task delay as a threshold for "immediate"
+        Assert.True(this._waitToWriteAsyncDelay < DefaultTaskDelay * 0.2);
+    }
+
+    private void ThenWaitToWriteAsyncResultShouldWaitForTasks()
+    {
+        // Using 90% of the default task delay as a threshold for "waiting"
+        Assert.True(this._waitToWriteAsyncDelay >= DefaultTaskDelay * 0.9);
+    }
+
+    private void ThenWriteAsyncResultShouldBeImmediate()
+    {
+        // Using 20% of the default task delay as a threshold for "immediate"
+        Assert.True(this._writeAsyncDelay < DefaultTaskDelay * 0.2);
+    }
+
+    private void ThenWriteAsyncResultShouldWaitForTasks()
+    {
+        // Using 90% of the default task delay as a threshold for "waiting"
+        Assert.True(this._writeAsyncDelay >= DefaultTaskDelay * 0.9);
+    }
+
+    private void ThenTryReadResultShouldBeFalse()
+    {
+        Assert.False(this._tryReadResult);
+    }
+
+    private void ThenTryReadTaskResultShouldBeNull()
+    {
+        Assert.Null(this._tryReadTaskResult);
+    }
+
+    private void ThenReadAsyncShouldNotReturnTask()
+    {
+        Assert.Null(this._readAsyncResult);
+    }
+
+    private void ThenReadAsyncShouldReturnTask()
+    {
+        Assert.NotNull(this._readAsyncResult);
+    }
+
+    private void ThenReadAsyncResultShouldExpire()
+    {
+        Assert.True(this._readWasCancelled);
+    }
+
+    private void ThenReadAsyncResultShouldWaitForTasks()
+    {
+        // Using 90% of the default task delay as a threshold for "waiting"
+        Assert.True(this._readAsyncDelay >= DefaultTaskDelay * 0.9);
+    }
+
+    private void ThenReadAllAsyncShouldNotReturnTask()
+    {
+        Assert.Null(this._readAllAsyncResult);
+    }
+
+    private void ThenReadAllAsyncShouldReturnTasks()
+    {
+        Assert.NotNull(this._readAllAsyncResult);
+        Assert.NotEmpty(this._readAllAsyncResult);
+    }
+
+    private void ThenReadAllAsyncResultShouldExpire()
+    {
+        Assert.True(this._readAllWasCancelled);
+    }
+
+    private void ThenReadAllAsyncResultShouldWaitForTasks()
+    {
+        // Using 90% of the default task delay as a threshold for "waiting"
+        Assert.True(this._readAllAsyncDelay >= DefaultTaskDelay * 0.9);
+    }
+
+    private void ThenReadAllAsyncResultShouldBeOrderedTasks()
+    {
+        Assert.Same(this._variedTasks![2], this._readAllAsyncResult![0]);
+        Assert.Same(this._variedTasks[4], this._readAllAsyncResult[1]);
+        Assert.Same(this._variedTasks[1], this._readAllAsyncResult[2]);
+        Assert.Same(this._variedTasks[0], this._readAllAsyncResult[3]);
+        Assert.Same(this._variedTasks[3], this._readAllAsyncResult[4]);
+    }
+
+    private void ThenWaitToReadAsyncShouldBeFalse()
+    {
+        Assert.False(this._waitToReadAsyncResult);
+    }
+
+    private void ThenWaitToReadAsyncShouldBeTrue()
+    {
+        Assert.True(this._waitToReadAsyncResult);
+    }
+
+    private void ThenWaitToReadAsyncResultShouldExpire()
+    {
+        Assert.True(this._waitToReadWasCancelled);
+    }
+
+    private void ThenWaitToReadAsyncResultShouldWaitForTasks()
+    {
+        // Using 90% of the default task delay as a threshold for "waiting"
+        Assert.True(this._waitToReadAsyncDelay >= DefaultTaskDelay * 0.9);
+    }
+}

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/EventGridClientAdapter.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/EventGridClientAdapter.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Messaging;
+using Azure.Messaging;
 using Azure.Messaging.EventGrid.Namespaces;
 
 namespace Workleap.DomainEventPropagation.EventGridClientAdapter;
@@ -12,28 +12,28 @@ internal sealed class EventGridClientAdapter : IEventGridClientAdapter
         this._adaptee = adaptee;
     }
 
-    public async Task<IEnumerable<EventBundle>> ReceiveCloudEventsAsync(string topicName, string eventSubscriptionName, CancellationToken cancellationToken)
+    public async Task<IEnumerable<EventBundle>> ReceiveCloudEventsAsync(string topicName, string eventSubscriptionName, int maxEvents, CancellationToken cancellationToken)
     {
-        var result = await this._adaptee.ReceiveCloudEventsAsync(topicName, eventSubscriptionName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var result = await this._adaptee.ReceiveCloudEventsAsync(topicName, eventSubscriptionName, maxEvents, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return result.HasValue
             ? result.Value.Value.Select(x => new EventBundle(x.Event, x.BrokerProperties.LockToken))
             : Array.Empty<EventBundle>();
     }
 
-    public Task AcknowledgeCloudEventAsync(string topicName, string eventSubscriptionName, string lockToken, CancellationToken cancellationToken)
+    public Task AcknowledgeCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken)
     {
-        return this._adaptee.AcknowledgeCloudEventsAsync(topicName, eventSubscriptionName, new AcknowledgeOptions(new[] { lockToken }), cancellationToken);
+        return this._adaptee.AcknowledgeCloudEventsAsync(topicName, eventSubscriptionName, new AcknowledgeOptions(lockTokens), cancellationToken);
     }
 
-    public Task ReleaseCloudEventAsync(string topicName, string eventSubscriptionName, string lockToken, CancellationToken cancellationToken)
+    public Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken)
     {
-        return this._adaptee.ReleaseCloudEventsAsync(topicName, eventSubscriptionName, new ReleaseOptions(new[] { lockToken }), cancellationToken: cancellationToken);
+        return this._adaptee.ReleaseCloudEventsAsync(topicName, eventSubscriptionName, new ReleaseOptions(lockTokens), cancellationToken: cancellationToken);
     }
 
-    public Task RejectCloudEventAsync(string topicName, string eventSubscriptionName, string lockToken, CancellationToken cancellationToken)
+    public Task RejectCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken)
     {
-        return this._adaptee.RejectCloudEventsAsync(topicName, eventSubscriptionName, new RejectOptions(new[] { lockToken }), cancellationToken);
+        return this._adaptee.RejectCloudEventsAsync(topicName, eventSubscriptionName, new RejectOptions(lockTokens), cancellationToken);
     }
 
     internal sealed record EventBundle(CloudEvent Event, string LockToken);

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/IEventGridClientAdapter.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/IEventGridClientAdapter.cs
@@ -1,12 +1,12 @@
-﻿namespace Workleap.DomainEventPropagation.EventGridClientAdapter;
+namespace Workleap.DomainEventPropagation.EventGridClientAdapter;
 
 internal interface IEventGridClientAdapter
 {
-    Task<IEnumerable<EventGridClientAdapter.EventBundle>> ReceiveCloudEventsAsync(string topicName, string eventSubscriptionName, CancellationToken cancellationToken);
+    Task<IEnumerable<EventGridClientAdapter.EventBundle>> ReceiveCloudEventsAsync(string topicName, string eventSubscriptionName, int maxEvents, CancellationToken cancellationToken);
 
-    Task AcknowledgeCloudEventAsync(string topicName, string eventSubscriptionName, string lockToken, CancellationToken cancellationToken);
+    Task AcknowledgeCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken);
 
-    Task ReleaseCloudEventAsync(string topicName, string eventSubscriptionName, string lockToken, CancellationToken cancellationToken);
+    Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken);
 
-    Task RejectCloudEventAsync(string topicName, string eventSubscriptionName, string lockToken, CancellationToken cancellationToken);
+    Task RejectCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken);
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Core;
+using Azure.Core;
 
 namespace Workleap.DomainEventPropagation;
 
@@ -15,4 +15,6 @@ public class EventPropagationSubscriptionOptions
     public string TopicName { get; set; } = string.Empty;
 
     public string SubscriptionName { get; set; } = string.Empty;
+
+    public int MaxDop { get; set; } = 1;
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Messaging;
+using System.Threading.Channels;
+using Azure.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -9,9 +10,7 @@ namespace Workleap.DomainEventPropagation;
 
 internal class EventPullerService : BackgroundService
 {
-    private readonly IServiceScopeFactory _serviceScopeFactory;
-    private readonly ILogger<EventPullerService> _logger;
-    private readonly EventGridTopicSubscription[] _eventGridTopicSubscriptions;
+    private readonly List<EventGridSubscriptionEventPuller> _eventGridSubscriptionPullers;
 
     public EventPullerService(
         IServiceScopeFactory serviceScopeFactory,
@@ -20,81 +19,170 @@ internal class EventPullerService : BackgroundService
         IOptionsMonitor<EventPropagationSubscriptionOptions> optionsMonitor,
         ILogger<EventPullerService> logger)
     {
-        this._serviceScopeFactory = serviceScopeFactory;
-        this._logger = logger;
-        this._eventGridTopicSubscriptions = clientDescriptors.Select(descriptor =>
-            new EventGridTopicSubscription(
-                optionsMonitor.Get(descriptor.Name).TopicName,
-                optionsMonitor.Get(descriptor.Name).SubscriptionName,
-                eventGridClientWrapperFactory.CreateClient(descriptor.Name))).ToArray();
+        this._eventGridSubscriptionPullers = clientDescriptors.Select(descriptor =>
+                new EventGridSubscriptionEventPuller(
+                    new EventGridTopicSubscription(
+                        optionsMonitor.Get(descriptor.Name).TopicName,
+                        optionsMonitor.Get(descriptor.Name).SubscriptionName,
+                        optionsMonitor.Get(descriptor.Name).MaxDop,
+                        eventGridClientWrapperFactory.CreateClient(descriptor.Name)),
+                    serviceScopeFactory,
+                    logger))
+            .ToList();
     }
 
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        return Task.WhenAll(this._eventGridTopicSubscriptions.Select(sub => Task.Run(() => this.StartReceivingEventsAsync(sub, stoppingToken), stoppingToken)));
+        return Task.WhenAll(this._eventGridSubscriptionPullers.Select(puller => Task.Run(() => puller.StartReceivingEventsAsync(stoppingToken), stoppingToken)));
     }
 
-    private async Task StartReceivingEventsAsync(EventGridTopicSubscription eventGridTopicSubscription, CancellationToken stoppingToken)
+    private class EventGridSubscriptionEventPuller
     {
-        using var scope = this._serviceScopeFactory.CreateScope();
-        var cloudEventHandler = scope.ServiceProvider.GetRequiredService<ICloudEventHandler>();
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+        private readonly ILogger<EventPullerService> _logger;
+        private readonly EventGridTopicSubscription _eventGridTopicSubscription;
 
-        while (!stoppingToken.IsCancellationRequested)
+        private readonly Channel<Task<EventHandlingResult>> _handlerTasksChannel;
+        private readonly Channel<string> _acknowledgeEventChannel = Channel.CreateUnbounded<string>();
+        private readonly Channel<string> _releaseEventChannel = Channel.CreateUnbounded<string>();
+        private readonly Channel<string> _rejectEventChannel = Channel.CreateUnbounded<string>();
+
+        public EventGridSubscriptionEventPuller(
+            EventGridTopicSubscription eventGridTopicSubscription,
+            IServiceScopeFactory serviceScopeFactory,
+            ILogger<EventPullerService> logger)
+        {
+            this._serviceScopeFactory = serviceScopeFactory;
+            this._logger = logger;
+            this._eventGridTopicSubscription = eventGridTopicSubscription;
+
+            this._handlerTasksChannel = new TaskBoundedChannel<Task<EventHandlingResult>>(this._eventGridTopicSubscription.MaxHandlerDop);
+        }
+
+        public Task StartReceivingEventsAsync(CancellationToken cancellationToken)
+        {
+            // Start the tasks that will feed events into the handler tasks channel and handle the completed event handlers
+            return Task.WhenAll(
+                this.FeedEventsIntoChannel(cancellationToken),
+                this.HandleCompletedEventHandlers(cancellationToken),
+                this.AcknowledgeEvents(cancellationToken),
+                this.ReleaseEvents(cancellationToken),
+                this.RejectEvents(cancellationToken));
+        }
+
+        private async Task FeedEventsIntoChannel(CancellationToken cancellationToken)
+        {
+            using var scope = this._serviceScopeFactory.CreateScope();
+            var cloudEventHandler = scope.ServiceProvider.GetRequiredService<ICloudEventHandler>();
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await this._handlerTasksChannel.Writer.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
+
+                    var bundles = await this._eventGridTopicSubscription.Client.ReceiveCloudEventsAsync(this._eventGridTopicSubscription.TopicName, this._eventGridTopicSubscription.SubscriptionName, this._eventGridTopicSubscription.MaxHandlerDop - this._handlerTasksChannel.Reader.Count, cancellationToken).ConfigureAwait(false);
+
+                    foreach (var bundle in bundles)
+                    {
+                        await this._handlerTasksChannel.Writer.WriteAsync(HandleEventAsync(cloudEventHandler, bundle.Event, bundle.LockToken, cancellationToken), cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    this._logger.CloudEventCouldNotBeHandled(this._eventGridTopicSubscription.TopicName, this._eventGridTopicSubscription.SubscriptionName, ex);
+                }
+            }
+        }
+
+        private static async Task<EventHandlingResult> HandleEventAsync(ICloudEventHandler cloudEventHandler, CloudEvent cloudEvent, string lockToken, CancellationToken cancellationToken)
         {
             try
             {
-                var bundles = await eventGridTopicSubscription.Client.ReceiveCloudEventsAsync(eventGridTopicSubscription.TopicName, eventGridTopicSubscription.SubscriptionName, cancellationToken: stoppingToken).ConfigureAwait(false);
-                foreach (var (cloudEvent, lockToken) in bundles)
-                {
-                    await this.HandleEventAsync(cloudEventHandler, eventGridTopicSubscription, cloudEvent, lockToken, stoppingToken).ConfigureAwait(false);
-                }
+                await cloudEventHandler.HandleCloudEventAsync(cloudEvent, cancellationToken).ConfigureAwait(false);
+                return new EventHandlingResult(cloudEvent, lockToken, null);
             }
             catch (Exception ex)
             {
-                this._logger.CloudEventCouldNotBeHandled(eventGridTopicSubscription.TopicName, eventGridTopicSubscription.SubscriptionName, ex);
+                return new EventHandlingResult(cloudEvent, lockToken, ex);
             }
         }
-    }
 
-    private async Task HandleEventAsync(ICloudEventHandler cloudEventHandler, EventGridTopicSubscription eventGridTopicSubscription, CloudEvent cloudEvent, string lockToken, CancellationToken stoppingToken)
-    {
-        try
+        private async Task HandleCompletedEventHandlers(CancellationToken cancellationToken)
         {
-            await cloudEventHandler.HandleCloudEventAsync(cloudEvent, stoppingToken).ConfigureAwait(false);
-            await AcknowledgeEvent(eventGridTopicSubscription, lockToken, stoppingToken).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            switch (ex)
+            // Read from the handler task channel and write to the appropriate channel based on the result
+            await foreach (var handlerTask in this._handlerTasksChannel.Reader.ReadAllAsync(cancellationToken))
             {
-                case DomainEventTypeNotRegisteredException:
-                case CloudEventSerializationException:
-                case DomainEventHandlerNotRegisteredException:
-                    this._logger.EventWillBeRejected(cloudEvent.Id, cloudEvent.Type, ex);
-                    await RejectEvent(eventGridTopicSubscription, lockToken, stoppingToken).ConfigureAwait(false);
-                    break;
-                default:
-                    this._logger.EventWillBeReleased(cloudEvent.Id, cloudEvent.Type, ex);
-                    await ReleaseEvent(eventGridTopicSubscription, lockToken, stoppingToken).ConfigureAwait(false);
-                    break;
+                var handlerResult = await handlerTask.ConfigureAwait(false);
+
+                switch (handlerResult.Exception)
+                {
+                    case null:
+                        await this._acknowledgeEventChannel.Writer.WriteAsync(handlerResult.LockToken, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case DomainEventTypeNotRegisteredException:
+                    case CloudEventSerializationException:
+                    case DomainEventHandlerNotRegisteredException:
+                        this._logger.EventWillBeRejected(handlerResult.CloudEvent.Id, handlerResult.CloudEvent.Type, handlerResult.Exception);
+                        await this._rejectEventChannel.Writer.WriteAsync(handlerResult.LockToken, cancellationToken).ConfigureAwait(false);
+                        break;
+                    default:
+                        this._logger.EventWillBeReleased(handlerResult.CloudEvent.Id, handlerResult.CloudEvent.Type, handlerResult.Exception);
+                        await this._releaseEventChannel.Writer.WriteAsync(handlerResult.LockToken, cancellationToken).ConfigureAwait(false);
+                        break;
+                }
             }
+        }
+
+        private async Task AcknowledgeEvents(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var lockTokens = await ReadCurrentChannelContent(this._acknowledgeEventChannel, cancellationToken).ConfigureAwait(false);
+                await this._eventGridTopicSubscription.Client.AcknowledgeCloudEventsAsync(this._eventGridTopicSubscription.TopicName, this._eventGridTopicSubscription.SubscriptionName, lockTokens, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task ReleaseEvents(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var lockTokens = await ReadCurrentChannelContent(this._releaseEventChannel, cancellationToken).ConfigureAwait(false);
+                await this._eventGridTopicSubscription.Client.ReleaseCloudEventsAsync(this._eventGridTopicSubscription.TopicName, this._eventGridTopicSubscription.SubscriptionName, lockTokens, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task RejectEvents(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var lockTokens = await ReadCurrentChannelContent(this._rejectEventChannel, cancellationToken).ConfigureAwait(false);
+                await this._eventGridTopicSubscription.Client.RejectCloudEventsAsync(this._eventGridTopicSubscription.TopicName, this._eventGridTopicSubscription.SubscriptionName, lockTokens, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task<List<string>> ReadCurrentChannelContent(Channel<string> channel, CancellationToken cancellationToken)
+        {
+            await channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false);
+
+            var currentChannelCount = channel.Reader.Count;
+            var results = new List<string>();
+
+            await foreach (var result in channel.Reader.ReadAllAsync(cancellationToken))
+            {
+                results.Add(result);
+
+                if (results.Count == currentChannelCount)
+                {
+                    break;
+                }
+            }
+
+            return results;
         }
     }
 
-    private static async Task AcknowledgeEvent(EventGridTopicSubscription eventGridTopicSubscription, string lockToken, CancellationToken stoppingToken)
-    { 
-        await eventGridTopicSubscription.Client.AcknowledgeCloudEventAsync(eventGridTopicSubscription.TopicName, eventGridTopicSubscription.SubscriptionName, lockToken, stoppingToken).ConfigureAwait(false);
-    }
-
-    private static async Task ReleaseEvent(EventGridTopicSubscription eventGridTopicSubscription, string lockToken, CancellationToken stoppingToken)
-    {
-        await eventGridTopicSubscription.Client.ReleaseCloudEventAsync(eventGridTopicSubscription.TopicName, eventGridTopicSubscription.SubscriptionName, lockToken, stoppingToken).ConfigureAwait(false);
-    }
-
-    private static async Task RejectEvent(EventGridTopicSubscription eventGridTopicSubscription, string lockToken, CancellationToken stoppingToken)
-    {
-        await eventGridTopicSubscription.Client.RejectCloudEventAsync(eventGridTopicSubscription.TopicName, eventGridTopicSubscription.SubscriptionName, lockToken, stoppingToken).ConfigureAwait(false);
-    }
-
-    private record EventGridTopicSubscription(string TopicName, string SubscriptionName, IEventGridClientAdapter Client);
+    private record EventGridTopicSubscription(string TopicName, string SubscriptionName, int MaxHandlerDop, IEventGridClientAdapter Client);
+    
+    private record EventHandlingResult(CloudEvent CloudEvent, string LockToken, Exception? Exception);
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/PublicAPI.Shipped.txt
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/PublicAPI.Shipped.txt
@@ -12,6 +12,8 @@ Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.TopicEndpoin
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.TopicEndpoint.set -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.TopicName.get -> string!
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.TopicName.set -> void
+Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxDop.get -> int
+Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxDop.set -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator.EventPropagationSubscriptionOptionsValidator() -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator.Validate(string! name, Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions! options) -> Microsoft.Extensions.Options.ValidateOptionsResult!

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/TaskBoundedChannel.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/TaskBoundedChannel.cs
@@ -1,0 +1,159 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Channels;
+
+namespace Workleap.DomainEventPropagation;
+
+/// <summary>
+/// Provides a channel with a bounded capacity that keeps tasks internally until they are completed and outputs them in order of completion.
+/// </summary>
+/// <typeparam name="T">The type of Task</typeparam>
+internal class TaskBoundedChannel<T> : Channel<T> where T : Task
+{
+    private readonly int _bufferedCapacity;
+    private readonly Channel<T> _outputChannel = Channel.CreateUnbounded<T>();
+    private readonly List<T> _tasks = [];
+
+    public TaskBoundedChannel(int bufferedCapacity)
+    {
+        this._bufferedCapacity = bufferedCapacity;
+        this.Reader = new TaskBoundedChannelReader(this);
+        this.Writer = new TaskBoundedChannelWriter(this);
+    }
+
+    private object SyncObj => this._tasks;
+
+    public class TaskBoundedChannelReader : ChannelReader<T>
+    {
+        private readonly TaskBoundedChannel<T> _parent;
+
+        public TaskBoundedChannelReader(TaskBoundedChannel<T> parent)
+        {
+            this._parent = parent;
+        }
+
+        public override bool CanCount => true;
+
+        public override int Count
+        {
+            get
+            {
+                lock (this._parent.SyncObj)
+                {
+                    return this._parent._tasks.Count;
+                }
+            }
+        }
+
+        public override bool TryRead([MaybeNullWhen(false)] out T item)
+        {
+            return this._parent._outputChannel.Reader.TryRead(out item);
+        }
+
+        public override ValueTask<T> ReadAsync(CancellationToken cancellationToken = default)
+        {
+            return this._parent._outputChannel.Reader.ReadAsync(cancellationToken);
+        }
+
+        public override IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default)
+        {
+            return this._parent._outputChannel.Reader.ReadAllAsync(cancellationToken);
+        }
+
+        public override ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken = default)
+        {
+            return this._parent._outputChannel.Reader.WaitToReadAsync(cancellationToken);
+        }
+    }
+
+    public class TaskBoundedChannelWriter : ChannelWriter<T>
+    {
+        private readonly TaskBoundedChannel<T> _parent;
+        private TaskCompletionSource _taskCompletionSource = new();
+
+        public TaskBoundedChannelWriter(TaskBoundedChannel<T> parent)
+        {
+            this._parent = parent;
+        }
+
+        public override bool TryComplete(Exception? exception = null)
+        {
+            return false;
+        }
+
+        public override bool TryWrite(T task)
+        {
+            lock (this._parent.SyncObj)
+            {
+                if (this._parent._tasks.Count < this._parent._bufferedCapacity)
+                {
+                    task.ContinueWith(this.OnTaskCompletion, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                    this._parent._tasks.Add(task);
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        public override ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<bool>(Task.FromCanceled<bool>(cancellationToken));
+            }
+
+            lock (this._parent.SyncObj)
+            {
+                // If there's space to write, a write is possible.
+                if (this._parent._tasks.Count < this._parent._bufferedCapacity)
+                {
+                    return new ValueTask<bool>(true);
+                }
+
+                // There's no space, so wait until there is.
+                return WaitForNextCompletedTask();
+
+                async ValueTask<bool> WaitForNextCompletedTask()
+                {
+                    await this._taskCompletionSource.Task.ConfigureAwait(false);
+                    return true;
+                }
+            }
+        }
+
+        public override async ValueTask WriteAsync(T task, CancellationToken cancellationToken = default)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                lock (this._parent.SyncObj)
+                {
+                    if (this._parent._tasks.Count < this._parent._bufferedCapacity)
+                    {
+                        this._parent._tasks.Add(task);
+                        task.ContinueWith(this.OnTaskCompletion, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                        return;
+                    }
+                }
+
+                await this.WaitToWriteAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private void OnTaskCompletion(Task task)
+        {
+            var typedTask = (T)task;
+            lock (this._parent.SyncObj)
+            {
+                this._parent._tasks.Remove(typedTask);
+                this._parent._outputChannel.Writer.TryWrite(typedTask);
+
+                if (this._parent._tasks.Count < this._parent._bufferedCapacity)
+                {
+                    var currentTcs = this._taskCompletionSource;
+                    this._taskCompletionSource = new();
+                    currentTcs.TrySetResult();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description of changes
When pulling events, the call to EventGrid asked for a single event, then processed the event, then called back to report (acknowledge, reject, release) before starting over and asking for the next single event.

This PR changes the behavior by accepting a new configuration on the subscription to allow running multiple domain event handlers in parallel. The call to EventGrid will request as many events as possible to fill the available space, improving the efficiency per roundtrip. A similar logic applies to the callbacks, where multiple token locks can be sent back at once.

For comparison, here are the results of running PullDeliveryTests.TestHeavyLoadOfEvents on the old implementation versus the new when configured for 500 handlers at once.

PREVIOUS IMPLEMENTATION
Processed 10 out of 10 events in 2664.5465 ms (3.75 event/second) with handler execution time at 250 ms
Processed 100 out of 100 events in 26631.8249 ms (3.75 event/second) with handler execution time at 250 ms
Processed 1000 out of 1000 events in 266582.5875 ms (3.75 event/second) with handler execution time at 250 ms
(Processing 10000 events reached the 5 minutes limit)

NEW IMPLEMENTATION
Processed 10 out of 10 events in 267.6413 ms (37.36 event/second) with handler execution time at 250 ms
Processed 100 out of 100 events in 358.0868 ms (279.26 event/second) with handler execution time at 250 ms
Processed 1000 out of 1000 events in 1087.8638 ms (919.23 event/second) with handler execution time at 250 ms
Processed 10000 out of 10000 events in 7067.7937 ms (1414.87 event/second) with handler execution time at 250 ms

In short, handling 100 events with the old system took 26s, and with the new system it takes 7s to handle 10k events.

## Breaking changes
There is a new configuration option on the subscription to control the degree of parallelism, but the default value is set to 1, so it should be retro compatible.

## Additional checks
- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
