### PR TITLE
[IDP-1699] Fix renovate for custom.regex on Docker image version in code

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
       "fileMatch": ["\\.cs$"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "WithImage(\"(?<imageName>.*?):(?<version>.*?)\")"
+        "(?<depName>workleap\\/eventgridemulator):(?<currentValue>[-a-z0-9.]*)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"

--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
       "fileMatch": ["\\.cs$"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "(?<depName>workleap\\/eventgridemulator):(?<currentValue>[-a-z0-9.]*)"
+        "(?<depName>workleap\\/eventgridemulator):(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+(-[-a-zA-Z0-9.]+)?)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/PullDeliveryTests.cs
@@ -124,7 +124,7 @@ public class PullDeliveryTests(ITestOutputHelper testOutputHelper)
         private static IContainer BuildContainer(string configurationPath)
         {
             return new ContainerBuilder()
-                .WithImage("workleap/eventgridemulator:0.2.0") // TODO Renovate this?
+                .WithImage("workleap/eventgridemulator:0.2.0")
                 .WithPortBinding(EmulatorPort, assignRandomHostPort: true)
                 .WithBindMount(configurationPath, "/app/appsettings.json", AccessMode.ReadOnly)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/PushDeliveryTests.cs
@@ -147,7 +147,7 @@ public class PushDeliveryTests(ITestOutputHelper testOutputHelper)
         private static IContainer BuildContainer(string configurationPath)
         {
             return new ContainerBuilder()
-                .WithImage("workleap/eventgridemulator:0.2.0") // TODO Renovate this?
+                .WithImage("workleap/eventgridemulator:0.2.0")
                 .WithPortBinding(EmulatorPort, assignRandomHostPort: true)
                 .WithBindMount(configurationPath, "/app/appsettings.json", AccessMode.ReadOnly)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(EmulatorPort))


### PR DESCRIPTION
## Description of changes
Renovate was broken due to depName and currentvalue fields missing.

Local execution
![image](https://github.com/gsoft-inc/wl-domain-event-propagation/assets/158102624/959ef416-962e-4c99-bf75-358421007c8d)

Closes #127 