### PR TITLE
[IDP-1715] Improve docs to show how to modify Event Grid client options and expose the client name

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,17 @@ public class ExampleDomainEventHandler : IDomainEventHandler<ExampleDomainEvent>
 }
 ```
 
+## Configure the underlying Event Grid clients options
+
+You can use the [named options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options#named-options-support-using-iconfigurenamedoptions) to configure the behavior of the underlying Event Grid clients. For instance:
+
+```csharp
+services.Configure<EventGridPublisherClientOptions>(EventPropagationPublisherOptions.EventGridClientName, options =>
+{
+    options.Retry.NetworkTimeout = TimeSpan.FromSeconds(15);
+});
+```
+
 ## Additional notes
 
 * You may only define one domain event handler per domain event you wish to handle. If you would require more, use the single allowed domain event handler as a facade for multiple operations.

--- a/src/Workleap.DomainEventPropagation.Publishing.Tests/EventPropagationClientTests.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing.Tests/EventPropagationClientTests.cs
@@ -24,8 +24,8 @@ public abstract class EventPropagationClientTests
     protected EventPropagationClientTests(IOptions<EventPropagationPublisherOptions> publisherOptions)
     {
         this._publisherOptions = publisherOptions;
-        A.CallTo(() => this.EventGridPublisherClientFactory.CreateClient(EventPropagationPublisherOptions.CustomTopicClientName)).Returns(this.EventGridPublisherClient);
-        A.CallTo(() => this.EventGridClientFactory.CreateClient(EventPropagationPublisherOptions.NamespaceTopicClientName)).Returns(this.EventGridClient);
+        A.CallTo(() => this.EventGridPublisherClientFactory.CreateClient(EventPropagationPublisherOptions.EventGridClientName)).Returns(this.EventGridPublisherClient);
+        A.CallTo(() => this.EventGridClientFactory.CreateClient(EventPropagationPublisherOptions.EventGridClientName)).Returns(this.EventGridClient);
 
         this.EventPropagationClient = new EventPropagationClient(
             this.EventGridPublisherClientFactory,

--- a/src/Workleap.DomainEventPropagation.Publishing.Tests/ServiceCollectionEventPropagationExtensionsTests.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing.Tests/ServiceCollectionEventPropagationExtensionsTests.cs
@@ -78,7 +78,7 @@ public class ServiceCollectionEventPropagationExtensionsTests
         services.AddEventPropagationPublisher();
         var serviceProvider = services.BuildServiceProvider();
         var clientFactory = serviceProvider.GetRequiredService<IAzureClientFactory<EventGridPublisherClient>>();
-        var client = clientFactory.CreateClient(EventPropagationPublisherOptions.CustomTopicClientName);
+        var client = clientFactory.CreateClient(EventPropagationPublisherOptions.EventGridClientName);
 
         // Then
         Assert.NotNull(client);
@@ -104,7 +104,7 @@ public class ServiceCollectionEventPropagationExtensionsTests
         });
         var serviceProvider = services.BuildServiceProvider();
         var clientFactory = serviceProvider.GetRequiredService<IAzureClientFactory<EventGridPublisherClient>>();
-        var client = clientFactory.CreateClient(EventPropagationPublisherOptions.CustomTopicClientName);
+        var client = clientFactory.CreateClient(EventPropagationPublisherOptions.EventGridClientName);
 
         // Then
         Assert.NotNull(client);

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
@@ -30,8 +30,8 @@ internal sealed class EventPropagationClient : IEventPropagationClient
     {
         this._eventPropagationPublisherOptions = eventPropagationPublisherOptions.Value;
         this._pipeline = publishingDomainEventBehaviors.Reverse().Aggregate((DomainEventsHandlerDelegate)this.SendDomainEventsAsync, BuildPipeline);
-        this._eventGridPublisherClient = eventGridPublisherClientFactory.CreateClient(EventPropagationPublisherOptions.CustomTopicClientName);
-        this._eventGridNamespaceClient = eventGridClientFactory.CreateClient(EventPropagationPublisherOptions.NamespaceTopicClientName);
+        this._eventGridPublisherClient = eventGridPublisherClientFactory.CreateClient(EventPropagationPublisherOptions.EventGridClientName);
+        this._eventGridNamespaceClient = eventGridClientFactory.CreateClient(EventPropagationPublisherOptions.EventGridClientName);
     }
 
     private static DomainEventsHandlerDelegate BuildPipeline(DomainEventsHandlerDelegate accumulator, IPublishingDomainEventBehavior next)

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherBuilder.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherBuilder.cs
@@ -42,11 +42,11 @@ internal sealed class EventPropagationPublisherBuilder : IEventPropagationPublis
     private static void ConfigureEventPublisherClients(AzureClientFactoryBuilder builder)
     {
         builder.AddClient<EventGridPublisherClient, EventGridPublisherClientOptions>(EventGridPublisherClientFactory)
-            .WithName(EventPropagationPublisherOptions.CustomTopicClientName)
+            .WithName(EventPropagationPublisherOptions.EventGridClientName)
             .ConfigureOptions(ConfigureClientOptions);
 
         builder.AddClient<EventGridClient, EventGridClientOptions>(EventGridClientFactory)
-            .WithName(EventPropagationPublisherOptions.NamespaceTopicClientName)
+            .WithName(EventPropagationPublisherOptions.EventGridClientName)
             .ConfigureOptions(ConfigureClientOptions);
     }
 

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptions.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationPublisherOptions.cs
@@ -12,10 +12,20 @@ public sealed class EventPropagationPublisherOptions
 {
     internal const string SectionName = "EventPropagation:Publisher";
 
-    // EventPropagationClient was the legacy name when only one kind of topic was supported
-    internal const string CustomTopicClientName = "EventPropagationClient";
-
-    internal const string NamespaceTopicClientName = "NamespaceTopicClient";
+    /// <summary>
+    /// This is the name of the underlying named options for <see cref="Azure.Messaging.EventGrid.EventGridPublisherClientOptions"/> and <see cref="Azure.Messaging.EventGrid.Namespaces.EventGridClientOptions"/>.
+    /// They are used when creating the corresponding <see cref="Azure.Messaging.EventGrid.EventGridPublisherClient"/> and <see cref="Azure.Messaging.EventGrid.Namespaces.EventGridClient"/>.
+    /// </summary>
+    /// <example>
+    /// Use this option name to customize the Event Grid clients.
+    /// <code>
+    /// services.Configure&lt;EventGridPublisherClientOptions&gt;(EventPropagationPublisherOptions.EventGridClientName, options =>
+    /// {
+    ///     // ...
+    /// }).
+    /// </code>
+    /// </example>
+    public const string EventGridClientName = "DomainEventPropagation";
 
     public string TopicAccessKey { get; set; } = string.Empty;
 

--- a/src/Workleap.DomainEventPropagation.Publishing/PublicAPI.Shipped.txt
+++ b/src/Workleap.DomainEventPropagation.Publishing/PublicAPI.Shipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+const Workleap.DomainEventPropagation.EventPropagationPublisherOptions.EventGridClientName = "DomainEventPropagation" -> string!
 static Workleap.DomainEventPropagation.ServiceCollectionEventPropagationExtensions.AddEventPropagationPublisher(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Workleap.DomainEventPropagation.IEventPropagationPublisherBuilder!
 static Workleap.DomainEventPropagation.ServiceCollectionEventPropagationExtensions.AddEventPropagationPublisher(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Workleap.DomainEventPropagation.EventPropagationPublisherOptions!>! configure) -> Workleap.DomainEventPropagation.IEventPropagationPublisherBuilder!
 Workleap.DomainEventPropagation.EventPropagationPublisherOptions


### PR DESCRIPTION
## Description of changes

- Add doc to show how to configure EventGridPublisherClientOptions and EventGridClientOptions.
- Changed the internal client names (previously `EventPropagationClient` and `NamespaceTopicClient`) to a public, single name `DomainEventPropagation`
  - I search for usage of these strings in our codebases => no results
  - It's ok to reuse the same string. .NET named options work per option type AND option name. We already did that in another lib (auditing).

## Breaking changes

- The Event Grid client names have changed but nobody was refering to them
- The client name is now publicly exposed for people to override the options

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [x] Updated the documentation of the project to reflect the changes
- [x] ~~Added new~~ Modified tests that cover the code changes
