### PR TITLE
Adding Configurable Exponential Backoff in Pull Delivery

### DIFF
--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoBogus" Version="2.13.1" />
     <PackageReference Include="CliWrap" Version="3.6.6" />
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
     <PackageReference Include="GSoft.Extensions.Xunit" Version="1.0.1" />

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/EventGridClientAdapter.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/EventGridClientAdapter.cs
@@ -17,8 +17,8 @@ internal sealed class EventGridClientAdapter : IEventGridClientAdapter
         var result = await this._adaptee.ReceiveCloudEventsAsync(topicName, eventSubscriptionName, maxEvents, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         return result.HasValue
-            ? result.Value.Value.Select(x => new EventBundle(x.Event, x.BrokerProperties.LockToken))
-            : Array.Empty<EventBundle>();
+            ? result.Value.Value.Select(x => new EventBundle(x.Event, x.BrokerProperties.LockToken, x.BrokerProperties.DeliveryCount))
+            : [];
     }
 
     public Task AcknowledgeCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken)
@@ -26,9 +26,9 @@ internal sealed class EventGridClientAdapter : IEventGridClientAdapter
         return this._adaptee.AcknowledgeCloudEventsAsync(topicName, eventSubscriptionName, new AcknowledgeOptions(lockTokens), cancellationToken);
     }
 
-    public Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken)
+    public Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, int releaseDelayInSeconds, CancellationToken cancellationToken)
     {
-        return this._adaptee.ReleaseCloudEventsAsync(topicName, eventSubscriptionName, new ReleaseOptions(lockTokens), cancellationToken: cancellationToken);
+        return this._adaptee.ReleaseCloudEventsAsync(topicName, eventSubscriptionName, new ReleaseOptions(lockTokens), releaseDelayInSeconds, cancellationToken);
     }
 
     public Task RejectCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken)
@@ -36,5 +36,5 @@ internal sealed class EventGridClientAdapter : IEventGridClientAdapter
         return this._adaptee.RejectCloudEventsAsync(topicName, eventSubscriptionName, new RejectOptions(lockTokens), cancellationToken);
     }
 
-    internal sealed record EventBundle(CloudEvent Event, string LockToken);
+    internal sealed record EventBundle(CloudEvent Event, string LockToken, int DeliveryCount);
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/EventGridClientAdapter.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/EventGridClientAdapter.cs
@@ -26,9 +26,9 @@ internal sealed class EventGridClientAdapter : IEventGridClientAdapter
         return this._adaptee.AcknowledgeCloudEventsAsync(topicName, eventSubscriptionName, new AcknowledgeOptions(lockTokens), cancellationToken);
     }
 
-    public Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, int releaseDelayInSeconds, CancellationToken cancellationToken)
+    public Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, TimeSpan releaseDelay, CancellationToken cancellationToken)
     {
-        return this._adaptee.ReleaseCloudEventsAsync(topicName, eventSubscriptionName, new ReleaseOptions(lockTokens), releaseDelayInSeconds, cancellationToken);
+        return this._adaptee.ReleaseCloudEventsAsync(topicName, eventSubscriptionName, new ReleaseOptions(lockTokens), releaseDelay.Seconds, cancellationToken);
     }
 
     public Task RejectCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken)

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/IEventGridClientAdapter.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/IEventGridClientAdapter.cs
@@ -6,7 +6,7 @@ internal interface IEventGridClientAdapter
 
     Task AcknowledgeCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken);
 
-    Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken);
+    Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, int releaseDelayInSeconds, CancellationToken cancellationToken);
 
     Task RejectCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken);
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/IEventGridClientAdapter.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventGridClientAdapter/IEventGridClientAdapter.cs
@@ -6,7 +6,7 @@ internal interface IEventGridClientAdapter
 
     Task AcknowledgeCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken);
 
-    Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, int releaseDelayInSeconds, CancellationToken cancellationToken);
+    Task ReleaseCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, TimeSpan releaseDelay, CancellationToken cancellationToken);
 
     Task RejectCloudEventsAsync(string topicName, string eventSubscriptionName, IEnumerable<string> lockTokens, CancellationToken cancellationToken);
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
@@ -18,5 +18,5 @@ public class EventPropagationSubscriptionOptions
 
     public int MaxDegreeOfParallelism { get; set; } = 1;
 
-    public IReadOnlyCollection<int>? RetryDelays { get; set; }
+    public IReadOnlyCollection<TimeSpan>? RetryDelays { get; set; }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
@@ -17,4 +17,6 @@ public class EventPropagationSubscriptionOptions
     public string SubscriptionName { get; set; } = string.Empty;
 
     public int MaxDegreeOfParallelism { get; set; } = 1;
+
+    public IReadOnlyCollection<int>? RetryDelays { get; set; }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -67,7 +67,7 @@ internal sealed class EventPullerService : BackgroundService
             this._logger = logger;
             this._eventGridTopicSubscription = eventGridTopicSubscription;
 
-            if (eventGridTopicSubscription.RetryDelays != null && eventGridTopicSubscription.RetryDelays.Any())
+            if (eventGridTopicSubscription.RetryDelays is { Count: > 0 })
             {
                 this._retryDelays = eventGridTopicSubscription.RetryDelays
                     .Select((x, index) => new { DeliveryCount = index + 1, Delay = x })

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -67,7 +67,7 @@ internal sealed class EventPullerService : BackgroundService
             this._logger = logger;
             this._eventGridTopicSubscription = eventGridTopicSubscription;
 
-            if (eventGridTopicSubscription.RetryDelays != null)
+            if (eventGridTopicSubscription.RetryDelays != null && eventGridTopicSubscription.RetryDelays.Any())
             {
                 this._retryDelays = eventGridTopicSubscription.RetryDelays
                     .Select((x, index) => new { DeliveryCount = index + 1, Delay = x })

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/PublicAPI.Shipped.txt
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/PublicAPI.Shipped.txt
@@ -14,7 +14,7 @@ Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.TopicName.ge
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.TopicName.set -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxDegreeOfParallelism.get -> int
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxDegreeOfParallelism.set -> void
-Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.RetryDelays.get -> System.Collections.Generic.IReadOnlyCollection<int>?
+Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.RetryDelays.get -> System.Collections.Generic.IReadOnlyCollection<System.TimeSpan>?
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.RetryDelays.set -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator.EventPropagationSubscriptionOptionsValidator() -> void

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/PublicAPI.Shipped.txt
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/PublicAPI.Shipped.txt
@@ -14,6 +14,8 @@ Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.TopicName.ge
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.TopicName.set -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxDegreeOfParallelism.get -> int
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxDegreeOfParallelism.set -> void
+Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.RetryDelays.get -> System.Collections.Generic.IReadOnlyCollection<int>?
+Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.RetryDelays.set -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator.EventPropagationSubscriptionOptionsValidator() -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator.Validate(string! name, Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions! options) -> Microsoft.Extensions.Options.ValidateOptionsResult!


### PR DESCRIPTION
## Description of changes
A new RetryDelays configuration parameter was added, which gives control over the delays before releasing the lock on failed domain events in Pull Delivery mode.

The tests were also completely rewritten, as dealing with the previous implementation with AutoBogus led to more issues than benefits.

## Breaking changes
If the new parameter is not set, a default implementation of an exponential backoff is provided. This means that after updating, failed domain events will be released over a progressively longer period time versus before, where they were immediately released.

## Additional checks
- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
