### PR TITLE
Limit the amount of events in Ack/Release/Reject calls

### DIFF
--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -231,7 +231,7 @@ internal sealed class EventPullerService : BackgroundService
 
         private static IEnumerable<EventBundle> ReadCurrentContent(Channel<EventBundle> channel)
         {
-            var maxResultCount = channel.Reader.Count;
+            var maxResultCount = Math.Min(channel.Reader.Count, MaxEventRequestSize);
             var resultCounter = 0;
 
             while (channel.Reader.TryRead(out var result))


### PR DESCRIPTION
## Description of changes
The maximum amount of lock tokens sent per call to Acknowledge, Release or Reject the events is now limited to 100.

While there is no easy to find documentation that states that this is the limit, a comment in the code pointed to this as the limit for the Receive call, and experience has shown that large number of events at once lead to a 400 BadRequest.

Limiting this could lower maximum throughput if more than 100 is supported, but could also enable maximum throughput if that limitation really exists.

## Breaking changes
There is no breaking change with this.

## Additional checks
- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
