### PR TITLE
Batch event publishing to stay under the limit

### DIFF
--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
@@ -118,7 +118,7 @@ internal sealed class EventPropagationClient : IEventPropagationClient
 
         foreach (var eventBatch in Chunk(eventGridEvents, EventGridMaxEventsPerBatch))
         {
-            await this._eventGridPublisherClient.SendEventsAsync(eventBatch, cancellationToken);
+            await this._eventGridPublisherClient.SendEventsAsync(eventBatch, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -144,9 +144,11 @@ internal sealed class EventPropagationClient : IEventPropagationClient
 
         foreach (var eventBatch in Chunk(cloudEvents, EventGridMaxEventsPerBatch))
         {
-            await (Task)(this._eventPropagationPublisherOptions.TopicType is TopicType.Namespace
+            var publishingTask = (Task)(this._eventPropagationPublisherOptions.TopicType is TopicType.Namespace
                 ? this._eventGridNamespaceClient.PublishCloudEventsAsync(topicName, eventBatch, cancellationToken)
                 : this._eventGridPublisherClient.SendEventsAsync(eventBatch, cancellationToken));
+
+            await publishingTask.ConfigureAwait(false);
         }
     }
 

--- a/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
+++ b/src/Workleap.DomainEventPropagation.Publishing/EventPropagationClient.cs
@@ -11,6 +11,7 @@ namespace Workleap.DomainEventPropagation;
 /// </summary>
 internal sealed class EventPropagationClient : IEventPropagationClient
 {
+    private const int EventGridMaxEventsPerBatch = 1000;
     private const string DomainEventDefaultVersion = "1.0";
 
     private readonly EventPropagationPublisherOptions _eventPropagationPublisherOptions;
@@ -94,7 +95,7 @@ internal sealed class EventPropagationClient : IEventPropagationClient
         };
     }
 
-    private Task SendEventGridEvents(
+    private async Task SendEventGridEvents(
         DomainEventWrapperCollection domainEventWrappers,
         CancellationToken cancellationToken)
     {
@@ -105,15 +106,23 @@ internal sealed class EventPropagationClient : IEventPropagationClient
             dataVersion: DomainEventDefaultVersion,
             data: new BinaryData(wrapper.Data)));
 
-        return topicType switch
+        switch (topicType)
         {
-            TopicType.Custom => this._eventGridPublisherClient.SendEventsAsync(eventGridEvents, cancellationToken),
-            TopicType.Namespace => throw new NotSupportedException("Cannot send EventGridEvents to a namespace topic"),
-            _ => throw new NotSupportedException($"Topic type {topicType} is not supported"),
-        };
+            case TopicType.Custom:
+                break;
+            case TopicType.Namespace:
+                throw new NotSupportedException("Cannot send EventGridEvents to a namespace topic");
+            default:
+                throw new NotSupportedException($"Topic type {topicType} is not supported");
+        }
+
+        foreach (var eventBatch in Chunk(eventGridEvents, EventGridMaxEventsPerBatch))
+        {
+            await this._eventGridPublisherClient.SendEventsAsync(eventBatch, cancellationToken);
+        }
     }
 
-    private Task SendCloudEvents(
+    private async Task SendCloudEvents(
         DomainEventWrapperCollection domainEventWrappers,
         CancellationToken cancellationToken)
     {
@@ -133,8 +142,31 @@ internal sealed class EventPropagationClient : IEventPropagationClient
 
         var topicName = this._eventPropagationPublisherOptions.TopicName;
 
-        return this._eventPropagationPublisherOptions.TopicType is TopicType.Namespace
-            ? this._eventGridNamespaceClient.PublishCloudEventsAsync(topicName, cloudEvents, cancellationToken)
-            : this._eventGridPublisherClient.SendEventsAsync(cloudEvents, cancellationToken);
+        foreach (var eventBatch in Chunk(cloudEvents, EventGridMaxEventsPerBatch))
+        {
+            await (Task)(this._eventPropagationPublisherOptions.TopicType is TopicType.Namespace
+                ? this._eventGridNamespaceClient.PublishCloudEventsAsync(topicName, eventBatch, cancellationToken)
+                : this._eventGridPublisherClient.SendEventsAsync(eventBatch, cancellationToken));
+        }
+    }
+
+    private static IEnumerable<List<T>> Chunk<T>(IEnumerable<T> source, int chunkSize)
+    {
+        var chunk = new List<T>(chunkSize);
+
+        foreach (var item in source)
+        {
+            chunk.Add(item);
+            if (chunk.Count == chunkSize)
+            {
+                yield return chunk;
+                chunk = new List<T>(chunkSize);
+            }
+        }
+
+        if (chunk.Any())
+        {
+            yield return chunk;
+        }
     }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -231,7 +231,7 @@ internal sealed class EventPullerService : BackgroundService
 
         private static IEnumerable<EventBundle> ReadCurrentContent(Channel<EventBundle> channel)
         {
-            var maxResultCount = channel.Reader.Count;
+            var maxResultCount = Math.Min(channel.Reader.Count, MaxEventRequestSize);
             var resultCounter = 0;
 
             while (channel.Reader.TryRead(out var result))


### PR DESCRIPTION
## Description of changes
Since the Event Publishing api limits the amount of events received at once at 1000, make sure that whenever we receive more events than the limit we break up the publishing in smaller calls.

Note: There is also technically a size limit (1 MiB) that isn't checked for Cloud Events. Additionally, while the documented limit for Custom Topics is 5000 events, the same limit as Namespace Topics (1000) was also applied for simplicity's sake.

## Breaking changes
None

## Additional checks
- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
