### PR TITLE
Map the intended delays to the nearest supported delay

### DIFF
--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPullerServiceTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPullerServiceTests.cs
@@ -12,7 +12,7 @@ namespace Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests;
 
 public class EventPullerServiceTests : IDisposable
 {
-    private static readonly List<TimeSpan> SupportedReleaseDelays = [TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(600), TimeSpan.FromSeconds(3600)];
+    private static readonly TimeSpan[] SupportedReleaseDelays = [TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(600), TimeSpan.FromSeconds(3600)];
 
     private readonly List<EventPullerClient> _clients = [];
     private readonly IServiceScopeFactory _scopeFactory;

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -42,7 +42,8 @@ internal sealed class EventPullerService : BackgroundService
     private class EventGridSubscriptionEventPuller
     {
         // At the moment the Release api only supports these delays
-        private static readonly List<TimeSpan> SupportedReleaseDelays = [TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(600), TimeSpan.FromSeconds(3600)];
+        // See https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.eventgrid.namespaces.eventgridclient.releasecloudeventsasync?view=azure-dotnet-preview#azure-messaging-eventgrid-namespaces-eventgridclient-releasecloudeventsasync(system-string-system-string-azure-core-requestcontent-system-nullable((system-int32))-azure-requestcontext)
+        private static readonly TimeSpan[] SupportedReleaseDelays = [TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(600), TimeSpan.FromSeconds(3600)];
 
         private const int OutputChannelSize = 5000;
         private const int MaxEventRequestSize = 100;


### PR DESCRIPTION
## Description of changes
When releasing an event lock in the Pull Delivery mode, it is possible to specify a release delay.

It turns out that the API allows an int, but will only support specific values for that parameter. This PR maps the intended delays to the nearest supported delay by the API, in order to prevent errors.

## Breaking changes
None

## Additional checks
- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
