### PR TITLE
[IDP-2334] Add client side max retries count for pull delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,10 +291,9 @@ public class ExampleDomainEventHandler : IDomainEventHandler<ExampleDomainEvent>
 
 #### Client Side Max Retries Count
 
-The client side max retries count can be configured by setting the `MaxRetries` property in the `EventGridSubscriptionClientOptions` object. The default value is 3.
+To ensure that messages end up in the Dead Letter Queue, a client-side retry count is required. Otherwise, when a message is requeued (released), Event Grid ignores the subscription retry count, and if the event exceeds its time-to-live, it is silently dropped.
 
-o ensure that messages end up in the Dead Letter Queue, a client-side retry count is required. Otherwise, when a message is requeued (released), Event Grid ignores the subscription max retries count, and if the event exceeds its time-to-live, it is silently dropped.
-
+It can be configured by setting the `MaxRetries` property in the `EventGridSubscriptionClientOptions`. The default value is 3.
 
 ## Configure the underlying Event Grid clients options
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Now, follow this [Microsoft documentation](https://learn.microsoft.com/en-us/azu
 
 ### Subscribe to domain events with pull delivery
 
-Install the package [Workleap.DomainEventPropagation.Subscription.PullDelivery](fixme) in your ASP.NET Core project that wants to receive events from Event Grid topics.
+Install the package [Workleap.DomainEventPropagation.Subscription.PullDelivery](https://www.nuget.org/packages/Workleap.DomainEventPropagation.Subscription.PullDelivery) in your ASP.NET Core project that wants to receive events from Event Grid topics.
 First, you will need to use one of the following methods to register the required services.
 
 ```csharp
@@ -202,6 +202,7 @@ services.AddPullDeliverySubscription()
       "TopicName": "<namespace_topic_to_listen_to>"
       "SubscriptionName": "<subscription_name_under_specified_topic>",
       "MaxDegreeOfParallelism": 10,
+      "MaxRetries": 3,
       "TopicAccessKey": "<secret_value>", // Can be omitted to use Azure Identity (RBAC)
     }
   }
@@ -220,6 +221,7 @@ services.AddPullDeliverySubscription()
       "TopicName": "<namespace_topic_to_listen_to>"
       "SubscriptionName": "<subscription_name_under_specified_topic>",
       "MaxDegreeOfParallelism": 10,
+      "MaxRetries": 3,
       "TopicAccessKey": "<secret_value>", // Can be omitted to use Azure Identity (RBAC)
     },
     "TopicSub2": {
@@ -227,6 +229,7 @@ services.AddPullDeliverySubscription()
       "TopicName": "<namespace_topic_to_listen_to>"
       "SubscriptionName": "<subscription_name_under_specified_topic>",
       "MaxDegreeOfParallelism": 10,
+      "MaxRetries": 10,
       "TopicAccessKey": "<secret_value>", // Can be omitted to use Azure Identity (RBAC)
     }
   }
@@ -246,6 +249,9 @@ services.AddPullDeliverySubscription()
 
     // Maximum degree of parallelism for processing events
     options.MaxDegreeOfParallelism = 10;
+    
+    // Client side max number of retries before being sent to the Dead Letter Queue
+    options.MaxRetries = 10;
 
     // Using an access key        
     options.TopicAccessKey = "<secret_value>";
@@ -282,6 +288,13 @@ public class ExampleDomainEventHandler : IDomainEventHandler<ExampleDomainEvent>
     }
 }
 ```
+
+#### Client Side Max Retries Count
+
+The client side max retries count can be configured by setting the `MaxRetries` property in the `EventGridSubscriptionClientOptions` object. The default value is 3.
+
+o ensure that messages end up in the Dead Letter Queue, a client-side retry count is required. Otherwise, when a message is requeued (released), Event Grid ignores the subscription max retries count, and if the event exceeds its time-to-live, it is silently dropped.
+
 
 ## Configure the underlying Event Grid clients options
 

--- a/src/Shared/LoggingExtensions.cs
+++ b/src/Shared/LoggingExtensions.cs
@@ -23,4 +23,7 @@ internal static partial class LoggingExtensions
 
     [LoggerMessage(6, LogLevel.Warning, "Failed to handle CloudEvents from the Event Grid topic {topicName} on subscription {subscription}")]
     public static partial void CloudEventCouldNotBeHandled(this ILogger logger, string topicName, string subscription, Exception ex);
+
+    [LoggerMessage(7, LogLevel.Information, "The event with {eventId} {EventName} will be rejected since it exceed the max retries count.")]
+    public static partial void EventWillBeRejectedDueToMaxRetries(this ILogger logger, string eventId, string eventName, Exception ex);
 }

--- a/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.9.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPropagationSubscriptionOptionsValidatorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPropagationSubscriptionOptionsValidatorTests.cs
@@ -9,39 +9,49 @@ public class EventPropagationSubscriptionOptionsValidatorTests
     [Theory]
 
     // Valid options
-    [InlineData("accessKey", false, "http://topicurl.com", "topicName", "subName", true)]
+    [InlineData("accessKey", false, "http://topicurl.com", "topicName", "subName", null, true)]
 
     // Access key
-    [InlineData(" ", false, "http://topicurl.com", "topicName", "subName", false)]
-    [InlineData(null, false, "http://topicurl.com", "topicName", "subName", false)]
+    [InlineData(" ", false, "http://topicurl.com", "topicName", "subName", null,false)]
+    [InlineData(null, false, "http://topicurl.com", "topicName", "subName", null,false)]
 
     // Token credential
-    [InlineData("accessKey", true, "http://topicurl.com", "topicName", "subName", true)]
+    [InlineData("accessKey", true, "http://topicurl.com", "topicName", "subName", null, true)]
 
     // Topic endpoint
-    [InlineData("accessKey", false, "invalid-url", "topicName", "subName", false)]
-    [InlineData("accessKey", false, null, "topicName", "subName", false)]
-    [InlineData("accessKey", false, " ", "topicName", "subName", false)]
+    [InlineData("accessKey", false, "invalid-url", "topicName", "subName", null,false)]
+    [InlineData("accessKey", false, null, "topicName", "subName", null, false)]
+    [InlineData("accessKey", false, " ", "topicName", "subName", null, false)]
 
     // Topic name
-    [InlineData("accessKey", false, "http://topicurl.com", " ", "subName", false)]
-    [InlineData("accessKey", false, "http://topicurl.com", null, "subName", false)]
+    [InlineData("accessKey", false, "http://topicurl.com", " ", "subName", null, false)]
+    [InlineData("accessKey", false, "http://topicurl.com", null, "subName",null, false)]
 
     // Subscription name
-    [InlineData("accessKey", false, "http://topicurl.com", "topicName", "", false)]
-    [InlineData("accessKey", false, "http://topicurl.com", "topicName", null, false)]
-    public void GivenNamedConfiguration_WhenValidate_ThenOptionsAreValidated(string topicAccessKey, bool useTokenCredential, string topicEndpoint, string topicName, string subName, bool validationSucceeded)
-    {
-        var validator = new EventPropagationSubscriptionOptionsValidator();
+    [InlineData("accessKey", false, "http://topicurl.com", "topicName", "", null,false)]
+    [InlineData("accessKey", false, "http://topicurl.com", "topicName", null,null, false)]
 
-        var result = validator.Validate("namedOptions", new EventPropagationSubscriptionOptions
+    // Max retries count
+    [InlineData("accessKey", false, "http://topicurl.com", "topicName", "", -1,false)]
+    [InlineData("accessKey", false, "http://topicurl.com", "topicName", null,11, false)]
+    public void GivenNamedConfiguration_WhenValidate_ThenOptionsAreValidated(string topicAccessKey, bool useTokenCredential, string topicEndpoint, string topicName, string subName, int? maxRetriesCount, bool validationSucceeded)
+    {
+        var option = new EventPropagationSubscriptionOptions
         {
             TokenCredential = useTokenCredential ? new DefaultAzureCredential() : default,
             TopicEndpoint = topicEndpoint,
             TopicAccessKey = topicAccessKey,
             TopicName = topicName,
             SubscriptionName = subName,
-        });
+        };
+
+        if(maxRetriesCount.HasValue)
+        {
+            option.MaxRetries = maxRetriesCount.Value;
+        }
+
+        var validator = new EventPropagationSubscriptionOptionsValidator();
+        var result = validator.Validate("namedOptions", option);
 
         Assert.Equal(validationSucceeded, result.Succeeded);
     }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPropagationSubscriptionOptionsValidatorTests.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/EventPropagationSubscriptionOptionsValidatorTests.cs
@@ -12,28 +12,28 @@ public class EventPropagationSubscriptionOptionsValidatorTests
     [InlineData("accessKey", false, "http://topicurl.com", "topicName", "subName", null, true)]
 
     // Access key
-    [InlineData(" ", false, "http://topicurl.com", "topicName", "subName", null,false)]
-    [InlineData(null, false, "http://topicurl.com", "topicName", "subName", null,false)]
+    [InlineData(" ", false, "http://topicurl.com", "topicName", "subName", null, false)]
+    [InlineData(null, false, "http://topicurl.com", "topicName", "subName", null, false)]
 
     // Token credential
     [InlineData("accessKey", true, "http://topicurl.com", "topicName", "subName", null, true)]
 
     // Topic endpoint
-    [InlineData("accessKey", false, "invalid-url", "topicName", "subName", null,false)]
+    [InlineData("accessKey", false, "invalid-url", "topicName", "subName", null, false)]
     [InlineData("accessKey", false, null, "topicName", "subName", null, false)]
     [InlineData("accessKey", false, " ", "topicName", "subName", null, false)]
 
     // Topic name
     [InlineData("accessKey", false, "http://topicurl.com", " ", "subName", null, false)]
-    [InlineData("accessKey", false, "http://topicurl.com", null, "subName",null, false)]
+    [InlineData("accessKey", false, "http://topicurl.com", null, "subName", null, false)]
 
     // Subscription name
-    [InlineData("accessKey", false, "http://topicurl.com", "topicName", "", null,false)]
-    [InlineData("accessKey", false, "http://topicurl.com", "topicName", null,null, false)]
+    [InlineData("accessKey", false, "http://topicurl.com", "topicName", "", null, false)]
+    [InlineData("accessKey", false, "http://topicurl.com", "topicName", null, null, false)]
 
     // Max retries count
-    [InlineData("accessKey", false, "http://topicurl.com", "topicName", "", -1,false)]
-    [InlineData("accessKey", false, "http://topicurl.com", "topicName", null,11, false)]
+    [InlineData("accessKey", false, "http://topicurl.com", "topicName", "", -1, false)]
+    [InlineData("accessKey", false, "http://topicurl.com", "topicName", null, 11, false)]
     public void GivenNamedConfiguration_WhenValidate_ThenOptionsAreValidated(string topicAccessKey, bool useTokenCredential, string topicEndpoint, string topicName, string subName, int? maxRetriesCount, bool validationSucceeded)
     {
         var option = new EventPropagationSubscriptionOptions
@@ -42,17 +42,17 @@ public class EventPropagationSubscriptionOptionsValidatorTests
             TopicEndpoint = topicEndpoint,
             TopicAccessKey = topicAccessKey,
             TopicName = topicName,
-            SubscriptionName = subName,
+            SubscriptionName = subName
         };
 
-        if(maxRetriesCount.HasValue)
+        if (maxRetriesCount.HasValue)
         {
             option.MaxRetries = maxRetriesCount.Value;
         }
 
         var validator = new EventPropagationSubscriptionOptionsValidator();
-        var result = validator.Validate("namedOptions", option);
+        var result = validator.Validate(name: "namedOptions", options: option);
 
-        Assert.Equal(validationSucceeded, result.Succeeded);
+        Assert.Equal(expected: validationSucceeded, actual: result.Succeeded);
     }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
@@ -18,5 +18,10 @@ public class EventPropagationSubscriptionOptions
 
     public int MaxDegreeOfParallelism { get; set; } = 1;
 
+    /// <summary>
+    /// Client side maximum retry count before sending the message to the dead-letter queue.
+    /// </summary>
+    public int MaxRetries { get; set; } = 3;
+
     public IReadOnlyCollection<TimeSpan>? RetryDelays { get; set; }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptionsValidator.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptionsValidator.cs
@@ -31,6 +31,11 @@ public class EventPropagationSubscriptionOptionsValidator : IValidateOptions<Eve
             return ValidateOptionsResult.Fail("A topic endpoint is required");
         }
 
+        if (options.MaxRetries is < 0 or > 10)
+        {
+            return ValidateOptionsResult.Fail("MaxRetries must be between 0 and 10. The upper limit ensures the event's time-to-live does not expire.");
+        }
+
         return ValidateOptionsResult.Success;
     }
 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -159,7 +159,7 @@ internal sealed class EventPullerService : BackgroundService
                         await this._rejectEventChannel.Writer.WriteAsync(eventBundle, cancellationToken).ConfigureAwait(false);
                         break;
                     default:
-                        this._logger.EventWillBeReleased(eventBundle.Event.Id, eventBundle.Event.Type, ex);
+                        this._logger.EventWillBeReleased(eventBundle.Event.Id, eventBundle.Event.Type, ex!);
                         await this._releaseEventChannel.Writer.WriteAsync(eventBundle, cancellationToken).ConfigureAwait(false);
                         break;
                 }

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/PublicAPI.Shipped.txt
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/PublicAPI.Shipped.txt
@@ -16,6 +16,8 @@ Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxDegreeOfP
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxDegreeOfParallelism.set -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.RetryDelays.get -> System.Collections.Generic.IReadOnlyCollection<System.TimeSpan>?
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.RetryDelays.set -> void
+Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxRetries.get -> int
+Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions.MaxRetries.set -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator.EventPropagationSubscriptionOptionsValidator() -> void
 Workleap.DomainEventPropagation.EventPropagationSubscriptionOptionsValidator.Validate(string! name, Workleap.DomainEventPropagation.EventPropagationSubscriptionOptions! options) -> Microsoft.Extensions.Options.ValidateOptionsResult!


### PR DESCRIPTION
## Description of changes
Add a client side max retries count for the delivery model.

When the delivery attend exceed the max retry configuration it get rejected to be send to the Dead Letter Queues instead of being released.

## Breaking changes
Not breaking but the behavior has changed: message will be put in DLG instead of being drop.

## Additional checks
- [X] Updated the documentation of the project to reflect the changes
- [X] Added new tests that cover the code changes
