### PR TITLE
[IDP-2061] Fix auto-merge and nuget conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - "renovate/**"
 
+# Prevent duplicate runs if Renovate falls back to creating a PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true      
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/Build.ps1
+++ b/Build.ps1
@@ -26,7 +26,7 @@ Process {
         Exec { & dotnet pack -c Release -o "$outputDir" }
 
         if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
-            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY }
+            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY --skip-duplicate }
         }
     }
     finally {


### PR DESCRIPTION
## Description of changes

- Skip nuget push duplicate.
- Setup concurrency option to prevent duplicate run when Renovate falls back to creating a PR

